### PR TITLE
Fix anti-aliasing issue

### DIFF
--- a/src/com/jediterm/swing/SwingTerminalPanel.java
+++ b/src/com/jediterm/swing/SwingTerminalPanel.java
@@ -395,13 +395,6 @@ public class SwingTerminalPanel extends JComponent implements TerminalDisplay, C
   }
 
   @Override
-  public void paint(Graphics g) {
-    setupAntialiasing(g, myAntialiasing);
-
-    super.paint(g);
-  }
-
-  @Override
   public void paintComponent(final Graphics g) {
     Graphics2D gfx = (Graphics2D)g;
     if (myImage != null) {


### PR DESCRIPTION
Hi !

Here is my proposition to fix the anti-aliasing issue when resizing the panel by hand.
Moreover, I've removed the overwritten _paint()_ method from _SwingTerminalPanel.java_, as it is not necessary.

Regards,
