### PR TITLE
Bug fix : crash when terminalPanel size does not match backBuffer size

### DIFF
--- a/src-emulator/com/jediterm/emulator/ui/SwingTerminalPanel.java
+++ b/src-emulator/com/jediterm/emulator/ui/SwingTerminalPanel.java
@@ -92,6 +92,8 @@ public class SwingTerminalPanel extends JComponent implements TerminalDisplay, C
     myScrollBuffer = scrollBuffer;
     myBackBuffer = backBuffer;
     myStyleState = styleState;
+    myTermSize.width = backBuffer.getWidth();
+    myTermSize.height = backBuffer.getHeight();
     myBoundedRangeModel.setRangeProperties(0, myTermSize.height, -scrollBuffer.getLineCount(), myTermSize.height, false);
   }
 


### PR DESCRIPTION
Hi Dmitry!

Here is a patch that fix a crash when you create a new `SwingTerminalPanel` with a `BackBuffer` which has a smaller size.
Once the terminal has reached the limit of the back buffer, an exception is thrown and the process won't recover.

Regards,
Clément
