### PR TITLE
Allow custom size (columns x lines) for SwingJediTerminal.

### DIFF
--- a/src-emulator/com/jediterm/emulator/ui/SwingJediTerminal.java
+++ b/src-emulator/com/jediterm/emulator/ui/SwingJediTerminal.java
@@ -28,13 +28,20 @@ public class SwingJediTerminal extends JPanel {
   private Thread emuThread;
 
   public SwingJediTerminal() {
+    this(80, 24);
+  }
+
+  public SwingJediTerminal(Dimension dimension) {
+    this(dimension.width, dimension.height);
+  }
+
+  public SwingJediTerminal(int columns, int lines) {
     super(new BorderLayout());
 
     StyleState styleState = createDefaultStyle();
 
     LinesBuffer scrollBuffer = new LinesBuffer();
-    BackBuffer backBuffer = new BackBuffer(80, 24, styleState, scrollBuffer);
-
+    BackBuffer backBuffer = new BackBuffer(columns, lines, styleState, scrollBuffer);
 
     termPanel = createTerminalPanel(styleState, backBuffer, scrollBuffer);
     terminalWriter = new BufferedTerminalWriter(termPanel, backBuffer, styleState);


### PR DESCRIPTION
Hi Dmitry!

I'm facing the need to spawn a terminal with a custom number of columns x lines (as soon as the terminal is started; a resize after the spawn is not really acceptable).

I wrote this patch to modify `SwingJediTerminal` constructors to handle this need.
Do you think this can be a part of the JediTerm API and should be merged?

Thanks!
Clément
