### PR TITLE
Fix a text-style error log when consuming an empty new line.

### DIFF
--- a/src-terminal/com/jediterm/terminal/display/BackBuffer.java
+++ b/src-terminal/com/jediterm/terminal/display/BackBuffer.java
@@ -368,8 +368,17 @@ public class BackBuffer implements StyledTextConsumer {
       }
     }
     //end row
-    if (lastStyle == null) {
-      LOG.error("Style is null for run supposed to be from " + beginRun + " to " + endCol + "on row " + row);
+
+    if (endCol == startCol) { // no run occurred : retrieve text style
+      final int location = row * myWidth + startCol;
+      if (location < 0 || location >= myStyleBuf.length) {
+        throw new IllegalStateException("Can't pump a char at " + row + "x" + startCol);
+      }
+      lastStyle = myStyleBuf[location];
+    }
+
+    if(lastStyle == null) {
+      LOG.error("Style is null for run supposed to be from " + beginRun + " to " + endCol + " on row " + row);
     }
     else {
       consumer.consume(beginRun, row, lastStyle, new CharBuffer(myBuf, row * myWidth + beginRun, endCol - beginRun), 0);

--- a/src-terminal/com/jediterm/terminal/emulator/JediEmulator.java
+++ b/src-terminal/com/jediterm/terminal/emulator/JediEmulator.java
@@ -57,7 +57,7 @@ public class JediEmulator extends DataStreamIteratingEmulator {
         break;
       case Ascii.FF: //Form Feed or New Page (NP). Ctrl-L treated the same as LF
       case Ascii.LF: //Line Feed or New Line (NL). (LF is Ctrl-J)
-      case Ascii.VT: //Vertical TAb (Ctrl-K). This is treated the sane as LF.
+      case Ascii.VT: //Vertical Tab (Ctrl-K). This is treated the sane as LF.
         // '\n'
         terminal.newLine();
         break;

--- a/tests/com/jediterm/BackBufferTest.java
+++ b/tests/com/jediterm/BackBufferTest.java
@@ -1,0 +1,49 @@
+package com.jediterm;
+
+import com.jediterm.terminal.StyledTextConsumer;
+import com.jediterm.terminal.TextStyle;
+import com.jediterm.terminal.display.*;
+import com.jediterm.util.BackBufferDisplay;
+import junit.framework.TestCase;
+
+/**
+ * @author traff
+ */
+public class BackBufferTest extends TestCase {
+  public void testEmptyLineTextStyle() {
+    StyleState state = new StyleState();
+
+    LinesBuffer scrollBuffer = new LinesBuffer();
+
+    BackBuffer backBuffer = new BackBuffer(15, 10, state, scrollBuffer);
+
+    BufferedDisplayTerminal terminal = new BufferedDisplayTerminal(new BackBufferDisplay(backBuffer), backBuffer, state);
+
+    terminal.writeString("  1. line1");
+    terminal.newLine();
+    terminal.carriageReturn();
+    terminal.writeString("  2. line2");
+    terminal.newLine();
+    terminal.carriageReturn();
+    terminal.newLine();
+    terminal.carriageReturn();
+    terminal.newLine();
+    terminal.carriageReturn();
+    terminal.writeString("  3. line3");
+    terminal.newLine();
+    terminal.carriageReturn();
+    terminal.newLine();
+    terminal.carriageReturn();
+
+    final int[] lines = {0};
+    backBuffer.processTextBuffer(0, 10, new StyledTextConsumer() {
+      @Override
+      public void consume(int x, int y, TextStyle style, CharBuffer characters, int startRow) {
+        assertNotNull(style);
+        lines[0]++;
+      }
+    });
+
+    assertEquals(lines[0], 6);
+  }
+}


### PR DESCRIPTION
Message was : "Style is null for run supposed to be from XXX to YYY on
row ZZZ".
