### PR TITLE
Add annotations.jar into build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -11,6 +11,7 @@
     <fileset dir="lib">
       <include name="guava*.jar"/>
       <include name="log4*.jar"/>
+      <include name="annotations.jar"/>
     </fileset>
   </path>
 


### PR DESCRIPTION
annotations.jar is missing in build.xml, preventing compilation.
