### PR TITLE
Fix ClassCastException in when prompted for password

### DIFF
--- a/src-terminal/com/jediterm/terminal/emulator/charset/CharacterSets.java
+++ b/src-terminal/com/jediterm/terminal/emulator/charset/CharacterSets.java
@@ -33,12 +33,12 @@ public final class CharacterSets {
     {0, "enq"}, //
     {0, "ack"}, //
     {0, "bel"}, //
-    {'\b', "bs"}, //
-    {'\t', "ht"}, //
-    {'\n', "lf"}, //
+    {(int) '\b', "bs"}, //
+    {(int) '\t', "ht"}, //
+    {(int) '\n', "lf"}, //
     {0, "vt"}, //
     {0, "ff"}, //
-    {'\r', "cr"}, //
+    {(int) '\r', "cr"}, //
     {0, "so"}, //
     {0, "si"}, //
     {0, "dle"}, //
@@ -152,7 +152,7 @@ public final class CharacterSets {
   public static char getChar(char original, GraphicSet gl, GraphicSet gr) {
     Object[] mapping = getMapping(original, gl, gr);
 
-    int ch = ((Integer)mapping[0]).intValue();
+    int ch = (Integer) mapping[0];
     if (ch > 0) {
       return (char)ch;
     }


### PR DESCRIPTION
when using SSH PreConnectHandler.

Stack is :
java.lang.ClassCastException: java.lang.Character cannot be cast to
java.lang.Integer
    at com.jediterm.terminal.emulator.charset.CharacterSets.getChar
(CharacterSets.java:159)
    at com.jediterm.terminal.emulator.charset.GraphicSetState.map
(GraphicSetState.java:79)
    at com.jediterm.terminal.display.JediTerminal.decode
(JediTerminal.java:141)
    at com.jediterm.terminal.display.JediTerminal.writeString
(JediTerminal.java:135)
    at com.jediterm.terminal.display.JediTerminal.writeUnwrappedString
(JediTerminal.java:168)
    at com.jediterm.terminal.ui.PreConnectHandler.questionVisible
(PreConnectHandler.java:31)
