### PR TITLE
Fix bug when scrolling in the scroll buffer

### DIFF
--- a/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
@@ -683,10 +683,13 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
     gfx.copyArea(0, Math.max(0, dyPix),
                  getPixelWidth(), getPixelHeight() - Math.abs(dyPix),
                  0, -dyPix);
+    //clear rect before drawing scroll buffer on it
+    gfx.setColor(getBackground());
     if (dy < 0) {
-      //clear rect before drawing scroll buffer on it
-      gfx.setColor(getBackground());
-      gfx.fillRect(0, Math.max(0, dyPix), getPixelWidth(), Math.abs(dyPix));
+      gfx.fillRect(0, 0, getPixelWidth(), Math.abs(dyPix));
+    }
+    else {
+      gfx.fillRect(0, getPixelHeight() - dyPix, getPixelWidth(), dyPix);
     }
   }
 


### PR DESCRIPTION
When scrolling down, if the new bottom line is shorter than the previous
one, then the tail of the previous bottom line is not cleared.
