### PR TITLE
Fix ConcurrentModificationException in ControlSequenceVisualizer

### DIFF
--- a/src-pty/com/jediterm/pty/PtyMain.java
+++ b/src-pty/com/jediterm/pty/PtyMain.java
@@ -36,7 +36,7 @@ public class PtyMain extends AbstractTerminalFrame {
 
 
   public static class LoggingPtyProcessTtyConnector extends PtyProcessTtyConnector implements LoggingTtyConnector {
-    private List<char[]> myDataChunks = Lists.newArrayList();
+    private List<char[]> myDataChunks = Lists.newCopyOnWriteArrayList();
 
     public LoggingPtyProcessTtyConnector(PtyProcess process, Charset charset) {
       super(process, charset);


### PR DESCRIPTION
Stack was : 

Exception in thread "AWT-EventQueue-0" java.util.ConcurrentModificationException
    at java.util.AbstractList$Itr.checkForComodification(AbstractList.java:372)
    at java.util.AbstractList$Itr.next(AbstractList.java:343)
    at com.jediterm.terminal.debug.ControlSequenceVisualizer.writeChunksToFile(ControlSequenceVisualizer.java:54)
    at com.jediterm.terminal.debug.ControlSequenceVisualizer.getVisualizedString(ControlSequenceVisualizer.java:30)
    at com.jediterm.terminal.debug.DebugBufferType$6.getValue(DebugBufferType.java:41)
    at com.jediterm.terminal.ui.JediTermWidget.getBufferText(JediTermWidget.java:133)
    at com.jediterm.terminal.debug.BufferPanel$1Updater.update(BufferPanel.java:37)
    at com.jediterm.terminal.debug.BufferPanel$1Updater.actionPerformed(BufferPanel.java:45)
    at javax.swing.Timer.fireActionPerformed(Timer.java:291)
    at javax.swing.Timer$DoPostEvent.run(Timer.java:221)
    at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:209)
    at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:641)
    at java.awt.EventQueue.access$000(EventQueue.java:84)
    at java.awt.EventQueue$1.run(EventQueue.java:602)
    at java.awt.EventQueue$1.run(EventQueue.java:600)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:87)
    at java.awt.EventQueue.dispatchEvent(EventQueue.java:611)
    at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:269)
    at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:184)
    at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:174)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:169)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:161)
    at java.awt.EventDispatchThread.run(EventDispatchThread.java:122)
