### PR TITLE
Set TERM to "xterm" when using JSchTtyConnector

### DIFF
--- a/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
+++ b/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
@@ -79,6 +79,7 @@ public class JSchTtyConnector implements TtyConnector {
       myInputStream = myChannelShell.getInputStream();
       myOutputStream = myChannelShell.getOutputStream();
       myInputStreamReader = new InputStreamReader(myInputStream, "utf-8");
+      myChannelShell.setPtyType("xterm");
       myChannelShell.connect();
       resizeImmediately();
       return true;


### PR DESCRIPTION
We set `TERM = "xterm"` when using `PtyConnector`, so here the same for `JSchTtyConnector`.
