### PR TITLE
Make session timeout customizable by overriding configureSession()

### DIFF
--- a/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
+++ b/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
@@ -109,15 +109,15 @@ public class JSchTtyConnector implements TtyConnector {
     config.put("compression.s2c", "zlib,none");
     config.put("compression.c2s", "zlib,none");
     configureSession(session, config);
-    session.setTimeout(5000);
     session.connect();
     session.setTimeout(0);
 
     return session;
   }
 
-  protected void configureSession(Session session, final java.util.Properties config) {
+  protected void configureSession(Session session, final java.util.Properties config) throws JSchException {
     session.setConfig(config);
+    session.setTimeout(5000);
   }
 
   private void getAuthDetails(Questioner q) {


### PR DESCRIPTION
5 seconds is a little to short for me.

This let a chance to the user to specify desired timeout, by overriding configureSession().
