### PR TITLE
Emulate X11 copy/paste mode

### DIFF
--- a/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
@@ -113,6 +113,9 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
         }
         repaint();
         mySelection.updateEnd(charCoords, myTermSize.width);
+        if (mySettingsProvider.emulateX11CopyPaste()) {
+          handleCopy(false);
+        }
 
         if (e.getPoint().y < 0) {
           moveScrollBar((int) ((e.getPoint().y) * SCROLL_SPEED));
@@ -162,12 +165,20 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
             Point stop = SelectionUtil.getNextSeparator(charCoords, myBackBuffer);
             mySelection = new TerminalSelection(start);
             mySelection.updateEnd(stop, myTermSize.width);
+            if (mySettingsProvider.emulateX11CopyPaste()) {
+              handleCopy(false);
+            }
           } else if (count == 3) {
             // select line
             final Point charCoords = panelToCharCoords(e.getPoint());
             mySelection = new TerminalSelection(new Point(0, charCoords.y));
             mySelection.updateEnd(new Point(myTermSize.width, charCoords.y), myTermSize.width);
+            if (mySettingsProvider.emulateX11CopyPaste()) {
+              handleCopy(false);
+            }
           }
+        } else if (e.getButton() == MouseEvent.BUTTON2 && mySettingsProvider.emulateX11CopyPaste()) {
+          handlePaste();
         } else if (e.getButton() == MouseEvent.BUTTON3) {
           JPopupMenu popup = createPopupMenu();
           popup.show(e.getComponent(), e.getX(), e.getY());
@@ -974,7 +985,7 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
         new TerminalAction("Copy", mySettingsProvider.getCopyKeyStrokes(), new Predicate<KeyEvent>() {
           @Override
           public boolean apply(KeyEvent input) {
-            return handleCopy(input);
+            return handleCopy(true);
           }
         }).withMnemonicKey(KeyEvent.VK_C).withEnabledSupplier(new Supplier<Boolean>() {
           @Override
@@ -1073,11 +1084,14 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
     pasteSelection();
   }
 
-  private boolean handleCopy(final KeyEvent e) {
+  // "unselect" is needed to handle Ctrl+C copy shortcut collision with ^C signal shortcut
+  private boolean handleCopy(boolean unselect) {
     if (mySelection != null) {
       copySelection(mySelection.getStart(), mySelection.getEnd());
-      mySelection = null;
-      repaint();
+      if (unselect) {
+        mySelection = null;
+        repaint();
+      }
       return true;
     }
     return false;

--- a/src-terminal/com/jediterm/terminal/ui/settings/DefaultSettingsProvider.java
+++ b/src-terminal/com/jediterm/terminal/ui/settings/DefaultSettingsProvider.java
@@ -91,6 +91,11 @@ public class DefaultSettingsProvider implements SettingsProvider {
   }
 
   @Override
+  public boolean emulateX11CopyPaste() {
+    return true;
+  }
+
+  @Override
   public boolean useAntialiasing() {
     return true;
   }

--- a/src-terminal/com/jediterm/terminal/ui/settings/UserSettingsProvider.java
+++ b/src-terminal/com/jediterm/terminal/ui/settings/UserSettingsProvider.java
@@ -21,6 +21,8 @@ public interface UserSettingsProvider {
 
   boolean useInverseSelectionColor();
 
+  public boolean emulateX11CopyPaste();
+
   boolean useAntialiasing();
 
   boolean shouldCloseTabOnLogout(TtyConnector ttyConnector);


### PR DESCRIPTION
This is a feature that I'm often requested for.

This patch add an option to emulate X11 copy/paste :
- on selection (mouse dragging or double/triple-click), selected text is automatically copied
- on middle-click (MouseEvent.BUTTON2), clipboard is pasted

Although this is optional, there is no conflict with copy/paste shortcut.
