### PR TITLE
Backspace send ^? instead of ^H

### DIFF
--- a/src-terminal/com/jediterm/terminal/TerminalKeyEncoder.java
+++ b/src-terminal/com/jediterm/terminal/TerminalKeyEncoder.java
@@ -21,6 +21,7 @@ public class TerminalKeyEncoder {
     putCode(VK_ENTER, Ascii.CR);
     arrowKeysApplicationSequences();
     keypadApplicationSequences();
+    putCode(VK_BACK_SPACE, Ascii.DEL);
     putCode(VK_F1, ESC, 'O', 'P');
     putCode(VK_F2, ESC, 'O', 'Q');
     putCode(VK_F3, ESC, 'O', 'R');


### PR DESCRIPTION
This is how it is done in gnome-terminal, xterm and konsole.
This fix emacs bug where backspace display the help.
See : http://www.ibb.net/~anne/keyboard.html
