### PR TITLE
Protect cursorPosition(x, y) against malformed sequences

### DIFF
--- a/src-terminal/com/jediterm/terminal/display/JediTerminal.java
+++ b/src-terminal/com/jediterm/terminal/display/JediTerminal.java
@@ -611,7 +611,6 @@ public class JediTerminal implements Terminal, TerminalMouseListener {
 
   @Override
   public void cursorPosition(int x, int y) {
-    myCursorX = x - 1;
     if (isOriginMode()) {
       myCursorY = y + scrollingRegionTop() - 1;
     }
@@ -623,9 +622,9 @@ public class JediTerminal implements Terminal, TerminalMouseListener {
       myCursorY = scrollingRegionBottom();
     }
 
-    if (myCursorX > myTerminalWidth) {
-      myCursorX = myTerminalWidth;
-    }
+    // avoid issue due to malformed sequence
+    myCursorX = Math.max(0, x - 1); 
+    myCursorX = Math.min(myCursorX, myTerminalWidth); 
 
     myDisplay.setCursor(myCursorX, myCursorY);
   }


### PR DESCRIPTION
Malformed "set cursor position" sequences were blowing the terminal.
