### PR TITLE
Clip to avoid glitches when drawing some non-monospaced graphical chars

### DIFF
--- a/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
@@ -796,9 +796,14 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
 
   private void drawCharacters(int x, int y, TextStyle style, CharBuffer buf, Graphics2D gfx) {
     gfx.setColor(getPalette().getColor(myStyleState.getBackground(style.getBackgroundForRun())));
-    gfx
-      .fillRect(x * myCharSize.width, (y - myClientScrollOrigin) * myCharSize.height, buf.getLength() * myCharSize.width,
-                myCharSize.height);
+    gfx.setClip(x * myCharSize.width,
+        (y - myClientScrollOrigin) * myCharSize.height,
+        buf.getLength() * myCharSize.width,
+        myCharSize.height);
+    gfx.fillRect(x * myCharSize.width,
+        (y - myClientScrollOrigin) * myCharSize.height,
+        buf.getLength() * myCharSize.width,
+        myCharSize.height);
 
     gfx.setFont(style.hasOption(TextStyle.Option.BOLD) ? myBoldFont : myNormalFont);
     gfx.setColor(getPalette().getColor(myStyleState.getForeground(style.getForegroundForRun())));


### PR DESCRIPTION
Clip rendering area to avoid characters being drawn bigger than expected (bug with supposed-to-be-monsopaced font)

Without clipping (notice the white pixel just over the mouse, and the double right columns) :
![yast](https://f.cloud.github.com/assets/3908084/1186489/73a6e9f6-2302-11e3-93cd-3dbb952d266e.png)

With clipping (no more corruption, but some graphical chars are cut; this is inevitable) :
![yast_clipped](https://f.cloud.github.com/assets/3908084/1186490/7513e686-2302-11e3-9711-b7540bba53ba.png)
