### PR TITLE
Keep colors in clearArea() and ICH

### DIFF
--- a/src-terminal/com/jediterm/terminal/display/BackBuffer.java
+++ b/src-terminal/com/jediterm/terminal/display/BackBuffer.java
@@ -161,7 +161,7 @@ public class BackBuffer implements StyledTextConsumer {
   }
 
   private void clearArea(final int leftX, final int topY, final int rightX, final int bottomY) {
-    clearArea(leftX, topY, rightX, bottomY, createEmptyStyleWithCurrentColor()); // TODO : should keep colors? What about elsewhere?
+    clearArea(leftX, topY, rightX, bottomY, createEmptyStyleWithCurrentColor());
   }
 
   private void clearArea(final int leftX, final int topY, final int rightX, final int bottomY, @NotNull TextStyle textStyle) {


### PR DESCRIPTION
I've checked that gnome-terminal and xterm behave the same.
