### PR TITLE
Set locale when using JSch connector

### DIFF
--- a/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
+++ b/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
@@ -77,6 +77,7 @@ public class JSchTtyConnector implements TtyConnector {
       myInputStream = myChannelShell.getInputStream();
       myOutputStream = myChannelShell.getOutputStream();
       myInputStreamReader = new InputStreamReader(myInputStream, "utf-8");
+      myChannelShell.setEnv("LANG", System.getenv().get("LANG"));
       myChannelShell.setPtyType("xterm");
       myChannelShell.connect();
       resizeImmediately();


### PR DESCRIPTION
This fix an issue when using "less".
The locale is not set (default = POSIX), so utf-8 chars are not properly handled by "less".
