### PR TITLE
Fix clipping issue with bold special characters

### DIFF
--- a/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
@@ -854,22 +854,13 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
 
     drawChars(x, y, buf, style, gfx);
 
-
-    gfx.setClip(x * myCharSize.width,
-                (y - myClientScrollOrigin) * myCharSize.height,
-                textLength * myCharSize.width,
-                myCharSize.height);
-
-
     gfx.setColor(getPalette().getColor(myStyleState.getForeground(style.getForegroundForRun())));
-
 
     int baseLine = (y + 1 - myClientScrollOrigin) * myCharSize.height - myDescent;
 
     if (style.hasOption(TextStyle.Option.UNDERLINED)) {
       gfx.drawLine(x * myCharSize.width, baseLine + 1, (x + textLength) * myCharSize.width, baseLine + 1);
     }
-    gfx.setClip(null);
   }
 
   /**
@@ -890,24 +881,23 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
 
       int descent = gfx.getFontMetrics(font).getDescent();
       int baseLine = (y + 1 - myClientScrollOrigin) * myCharSize.height - descent;
-      int charWidth = gfx.getFontMetrics(font).charsWidth(buf.getBuf(), buf.getStart() + offset, newBlockLen);
-
       int xCoord = (x + drawCharsOffset) * myCharSize.width;
+      int textLength = CharacterUtils.getTextLength(buf.getBuf(), buf.getStart() + offset, newBlockLen);
 
       gfx.setClip(xCoord,
                   (y - myClientScrollOrigin) * myCharSize.height,
-                  charWidth,
+                  textLength * myCharSize.width,
                   myCharSize.height);
       gfx.setColor(getPalette().getColor(myStyleState.getForeground(style.getForegroundForRun())));
-      
-      gfx.drawChars(buf.getBuf(), buf.getStart() + offset, newBlockLen, xCoord, baseLine);
-      
 
-      drawCharsOffset += CharacterUtils.getTextLength(buf.getBuf(), buf.getStart() + offset, newBlockLen);
+      gfx.drawChars(buf.getBuf(), buf.getStart() + offset, newBlockLen, xCoord, baseLine);
+
+      drawCharsOffset += textLength;
       offset += newBlockLen;
 
       newBlockLen = 1;
     }
+    gfx.setClip(null);
   }
 
   protected Font getFontToDisplay(char c, TextStyle style) {


### PR DESCRIPTION
fc0abfae113f185cd4ccfebab2a3e0168b5224d3 re-introduced the clipping bug https://github.com/JetBrains/jediterm/issues/60, where characters are drawn outside their cell bounds.

Clipping computation based on `gfx.getFontMetrics(font).charsWidth()` is kind of a no-op, because it is precisely the width the text will want to take. So it won't avoid too large text rendering.

I've fixed and moved the clipping logic in `drawChars()`.
