### PR TITLE
Deactivate mouse selection when mouse reporting is activated

### DIFF
--- a/src-terminal/com/jediterm/terminal/TerminalDisplay.java
+++ b/src-terminal/com/jediterm/terminal/TerminalDisplay.java
@@ -1,6 +1,7 @@
 package com.jediterm.terminal;
 
 import com.jediterm.terminal.display.JediTerminal;
+import com.jediterm.terminal.emulator.mouse.MouseMode;
 
 import java.awt.*;
 
@@ -25,4 +26,6 @@ public interface TerminalDisplay {
   void setBlinkingCursor(boolean enabled);
 
   void setWindowTitle(String name);
+
+  void terminalMouseModeSet(MouseMode mode);
 }

--- a/src-terminal/com/jediterm/terminal/display/JediTerminal.java
+++ b/src-terminal/com/jediterm/terminal/display/JediTerminal.java
@@ -757,8 +757,8 @@ public class JediTerminal implements Terminal, TerminalMouseListener {
   }
 
   private void initMouseModes() {
-    myMouseMode = MouseMode.MOUSE_REPORTING_NONE;
-    myMouseFormat = MouseFormat.MOUSE_FORMAT_XTERM;
+    setMouseMode(MouseMode.MOUSE_REPORTING_NONE);
+    setMouseFormat(MouseFormat.MOUSE_FORMAT_XTERM);
   }
 
   private void initModes() {
@@ -896,6 +896,7 @@ public class JediTerminal implements Terminal, TerminalMouseListener {
   @Override
   public void setMouseMode(@NotNull MouseMode mode) {
     myMouseMode = mode;
+    myDisplay.terminalMouseModeSet(mode);
   }
 
   @Override

--- a/src-terminal/com/jediterm/terminal/emulator/JediEmulator.java
+++ b/src-terminal/com/jediterm/terminal/emulator/JediEmulator.java
@@ -493,10 +493,10 @@ public class JediEmulator extends DataStreamIteratingEmulator {
           return true;
         case 1003:
           if (enabled) {
-            myTerminal.setMouseMode(MouseMode.MOUSE_REPORTING_ALL_MOTION);
+            setMouseMode(MouseMode.MOUSE_REPORTING_ALL_MOTION);
           }
           else {
-            myTerminal.setMouseMode(MouseMode.MOUSE_REPORTING_NONE);
+            setMouseMode(MouseMode.MOUSE_REPORTING_NONE);
           }
           return true;
         case 1005:

--- a/tests/com/jediterm/util/BackBufferDisplay.java
+++ b/tests/com/jediterm/util/BackBufferDisplay.java
@@ -5,6 +5,7 @@ import com.jediterm.terminal.TerminalDisplay;
 import com.jediterm.terminal.display.BackBuffer;
 import com.jediterm.terminal.display.JediTerminal;
 import com.jediterm.terminal.display.TerminalSelection;
+import com.jediterm.terminal.emulator.mouse.MouseMode;
 
 import java.awt.*;
 
@@ -31,12 +32,10 @@ public class BackBufferDisplay implements TerminalDisplay {
 
   @Override
   public void setCursor(int x, int y) {
-
   }
 
   @Override
   public void beep() {
-
   }
 
   @Override
@@ -58,12 +57,10 @@ public class BackBufferDisplay implements TerminalDisplay {
 
   @Override
   public void setBlinkingCursor(boolean enabled) {
-
   }
 
   @Override
   public void setWindowTitle(String name) {
-    
   }
 
   public TerminalSelection getSelection() {
@@ -72,5 +69,9 @@ public class BackBufferDisplay implements TerminalDisplay {
 
   public void setSelection(TerminalSelection mySelection) {
     this.mySelection = mySelection;
+  }
+
+  @Override
+  public void terminalMouseModeSet(MouseMode mode) {
   }
 }


### PR DESCRIPTION
In MC for example, when double-clicking to open a directory, the area where the directory name was displayed is then selected.

This patch disable selection when mouse reporting is activated, fixing this unwanted behavior.
