### PR TITLE
Fix a NPE when LANG is not defined (typically on Windows)

### DIFF
--- a/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
+++ b/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
@@ -77,7 +77,8 @@ public class JSchTtyConnector implements TtyConnector {
       myInputStream = myChannelShell.getInputStream();
       myOutputStream = myChannelShell.getOutputStream();
       myInputStreamReader = new InputStreamReader(myInputStream, "utf-8");
-      myChannelShell.setEnv("LANG", System.getenv().get("LANG"));
+      String lang = System.getenv().get("LANG");
+      myChannelShell.setEnv("LANG", lang != null ? lang : "en_US.UTF-8");
       myChannelShell.setPtyType("xterm");
       myChannelShell.connect();
       resizeImmediately();


### PR DESCRIPTION
If LANG is not defined, we end up with trying to add "null" in a hashtable, which is not allowed, throwing a NPE.

The default "en_US.UTF-8" should be an option, but we have no access to SettingProvider here, and I've decided to keep it as a simple bug fix.
