### PR TITLE
Fix X10 compatibility mode reporting, not supposed to use UTF-8

### DIFF
--- a/src-terminal/com/jediterm/terminal/display/JediTerminal.java
+++ b/src-terminal/com/jediterm/terminal/display/JediTerminal.java
@@ -789,6 +789,7 @@ public class JediTerminal implements Terminal, TerminalMouseListener {
 
   private byte[] mouseReport(int button, int x, int y) {
     StringBuilder sb = new StringBuilder();
+    String charset = "UTF-8"; // extended mode requires UTF-8 encoding
     switch (myMouseFormat) {
       case MOUSE_FORMAT_XTERM_EXT:
         sb.append(String.format("\033[M%c%c%c",
@@ -814,10 +815,12 @@ public class JediTerminal implements Terminal, TerminalMouseListener {
         break;
       case MOUSE_FORMAT_XTERM:
       default:
+        charset = "US-ASCII"; // X10 compatibility mode requires ASCII
         sb.append(String.format("\033[M%c%c%c", (char)(32 + button), (char)(32 + x), (char)(32 + y)));
         break;
     }
-    return sb.toString().getBytes(Charset.forName("UTF-8"));
+    LOG.debug(myMouseFormat + " (" + charset + ") report : " + button + ", " + x + "x" + y + " = " + sb);
+    return sb.toString().getBytes(Charset.forName(charset));
   }
 
 


### PR DESCRIPTION
See "Extended coordinates - UTF-8 (1005)" at 
http://invisible-island.net/xterm/ctlseqs/ctlseqs.html#Mouse%20Tracking

This enables UTF-8 encoding for C x and C y under all tracking modes,
expanding the maximum encodable position from 223 to 2015. For positions
less than 95, the resulting output is identical under both modes. Under
extended mouse mode, positions greater than 95 generate "extra" bytes
which will confuse applications which do not treat their input as a
UTF-8 stream. Likewise, C b will be UTF-8 encoded, to reduce confusion
with wheel mouse events.
Under normal mouse mode, positions outside (160,94) result in byte pairs
which can be interpreted as a single UTF-8 character; applications which
do treat their input as UTF-8 will almost certainly be confused unless
extended mouse mode is active.
