### PR TITLE
Make DEC Compatibility Mode substantially faster

### DIFF
--- a/src-terminal/com/jediterm/terminal/CharacterUtils.java
+++ b/src-terminal/com/jediterm/terminal/CharacterUtils.java
@@ -255,7 +255,7 @@ public class CharacterUtils {
   public static CharBuffer heavyDecCompatibleBuffer(CharBuffer buf) {
     char[] c = Arrays.copyOfRange(buf.getBuf(), 0, buf.getBuf().length);
     for(int i = 0; i < c.length; i++) {
-      c[i] = CharacterSets.getHeavyDecSpecialChar(c[i]);
+      c[i] = CharacterSets.getHeavyDecBoxChar(c[i]);
     }
     return new CharBuffer(c, buf.getStart(), buf.getLength());
   }

--- a/src-terminal/com/jediterm/terminal/emulator/charset/CharacterSets.java
+++ b/src-terminal/com/jediterm/terminal/emulator/charset/CharacterSets.java
@@ -134,7 +134,10 @@ public final class CharacterSets {
     {' ', null}, //
   };
 
-  public static boolean isDecSpecialChar(char c) {
+  public static boolean isDecBoxChar(char c) {
+    if (c < '\u2500' || c >= '\u2580') { // fast path
+      return false;
+    }
     for (Object[] o : DEC_SPECIAL_CHARS) {
       if (c == (Character) o[0]) {
         return true;
@@ -143,7 +146,10 @@ public final class CharacterSets {
     return false;
   }
   
-  public static char getHeavyDecSpecialChar(char c) {
+  public static char getHeavyDecBoxChar(char c) {
+    if (c < '\u2500' || c >= '\u2580') { // fast path
+      return c;
+    }
     for (Object[] o : DEC_SPECIAL_CHARS) {
       if (c == (Character) o[0]) {
         return o[1] != null ? (Character) o[1] : c;

--- a/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
@@ -941,7 +941,7 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
   protected Font getFontToDisplay(char c, TextStyle style) {
     boolean bold = style.hasOption(TextStyle.Option.BOLD);
     // workaround to fix Swing bad rendering of bold special chars on Linux
-    if (bold && mySettingsProvider.DECCompatibilityMode() && CharacterSets.isDecSpecialChar(c)) {
+    if (bold && mySettingsProvider.DECCompatibilityMode() && CharacterSets.isDecBoxChar(c)) {
       return myNormalFont;
     }
     return bold ? myBoldFont : myNormalFont;


### PR DESCRIPTION
DEC Compatibility Mode is slow when in full screen, with a lot of bold chars.

See : http://unicode-table.com/en/sections/box-drawing/ for unicode used.
