### PR TITLE
Add support for italic fonts.

### DIFF
--- a/src-terminal/com/jediterm/terminal/TextStyle.java
+++ b/src-terminal/com/jediterm/terminal/TextStyle.java
@@ -173,6 +173,7 @@ public class TextStyle implements Cloneable {
 
   public enum Option {
     BOLD,
+    ITALIC,
     BLINK,
     DIM,
     INVERSE,

--- a/src-terminal/com/jediterm/terminal/emulator/JediEmulator.java
+++ b/src-terminal/com/jediterm/terminal/emulator/JediEmulator.java
@@ -1,7 +1,14 @@
 package com.jediterm.terminal.emulator;
 
 import com.google.common.base.Ascii;
-import com.jediterm.terminal.*;
+import com.jediterm.terminal.CharacterUtils;
+import com.jediterm.terminal.DataStreamIteratingEmulator;
+import com.jediterm.terminal.Terminal;
+import com.jediterm.terminal.TerminalColor;
+import com.jediterm.terminal.TerminalDataStream;
+import com.jediterm.terminal.TerminalMode;
+import com.jediterm.terminal.TerminalOutputStream;
+import com.jediterm.terminal.TextStyle;
 import com.jediterm.terminal.emulator.mouse.MouseFormat;
 import com.jediterm.terminal.emulator.mouse.MouseMode;
 import org.apache.log4j.Logger;
@@ -767,6 +774,9 @@ public class JediEmulator extends DataStreamIteratingEmulator {
         case 2:// Dim
           textStyle.setOption(TextStyle.Option.DIM, true);
           break;
+        case 3:// Italic
+          textStyle.setOption(TextStyle.Option.ITALIC, true);
+          break;
         case 4:// Underlined
           textStyle.setOption(TextStyle.Option.UNDERLINED, true);
           break;
@@ -782,6 +792,9 @@ public class JediEmulator extends DataStreamIteratingEmulator {
         case 22: //Normal (neither bold nor faint)
           textStyle.setOption(TextStyle.Option.BOLD, false);
           textStyle.setOption(TextStyle.Option.DIM, false);
+          break;
+        case 23: // Not italic
+          textStyle.setOption(TextStyle.Option.ITALIC, false);
           break;
         case 24: // Not underlined
           textStyle.setOption(TextStyle.Option.UNDERLINED, false);

--- a/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
@@ -52,7 +52,9 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
 
   /*font related*/
   private Font myNormalFont;
+  private Font myItalicFont;
   private Font myBoldFont;
+  private Font myBoldItalicFont;
   private int myDescent = 0;
   protected Dimension myCharSize = new Dimension();
   private boolean myMonospaced;
@@ -105,6 +107,8 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
   public void init() {
     myNormalFont = createFont();
     myBoldFont = myNormalFont.deriveFont(Font.BOLD);
+    myItalicFont = myNormalFont.deriveFont(Font.ITALIC);
+    myBoldItalicFont = myBoldFont.deriveFont(Font.ITALIC);
 
     establishFontMetrics();
 
@@ -892,6 +896,7 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
     int drawCharsOffset = 0;
     
     // workaround to fix Swing bad rendering of bold special chars on Linux
+    // TODO required for italic?
     CharBuffer renderingBuffer;
     if(mySettingsProvider.DECCompatibilityMode() && style.hasOption(TextStyle.Option.BOLD)) {
       renderingBuffer = CharacterUtils.heavyDecCompatibleBuffer(buf);
@@ -930,11 +935,14 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
 
   protected Font getFontToDisplay(char c, TextStyle style) {
     boolean bold = style.hasOption(TextStyle.Option.BOLD);
+    boolean italic = style.hasOption(TextStyle.Option.ITALIC);
     // workaround to fix Swing bad rendering of bold special chars on Linux
+    // TODO required for italic?
     if (bold && mySettingsProvider.DECCompatibilityMode() && CharacterSets.isDecSpecialChar(c)) {
       return myNormalFont;
     }
-    return bold ? myBoldFont : myNormalFont;
+    return bold ? (italic ? myBoldItalicFont : myBoldFont)
+                : (italic ? myItalicFont : myNormalFont);
   }
 
   private ColorPalette getPalette() {


### PR DESCRIPTION
Note, when this updated version is made available to IntelliJ, the following change must be made to `JBTerminalPanel`:

``` java
  @Override
  protected Font getFontToDisplay(char c, TextStyle style) {
    boolean bold = style.hasOption(TextStyle.Option.BOLD);
    boolean italic = style.hasOption(TextStyle.Option.ITALIC);
    int fontStyle =
        (bold ? Font.BOLD : Font.PLAIN) |
        (italic? Font.ITALIC : Font.PLAIN);
    FontInfo fontInfo = fontForChar(c, fontStyle);
    return fontInfo.getFont();
  }
```
