### PR TITLE
Fix StringIndexOutOfBoundsException in SelectionUtil.getSelectionText()

### DIFF
--- a/src-terminal/com/jediterm/terminal/model/SelectionUtil.java
+++ b/src-terminal/com/jediterm/terminal/model/SelectionUtil.java
@@ -54,9 +54,10 @@ public class SelectionUtil {
                                         final TerminalTextBuffer terminalTextBuffer) {
 
     Pair<Point, Point> pair = sortPoints(selectionStart, selectionEnd);
+    pair.first.y = Math.max(pair.first.y, - terminalTextBuffer.getHistoryLinesCount());
+    pair = sortPoints(pair.first, pair.second); // previous line may have change the order
 
     Point top = pair.first;
-    top.y = Math.max(top.y, - terminalTextBuffer.getHistoryLinesCount());
     Point bottom = pair.second;
 
     final StringBuilder selectionText = new StringBuilder();


### PR DESCRIPTION
``` java
Exception in thread "AWT-EventQueue-0" java.lang.StringIndexOutOfBoundsException: String index out of range: -5
    at java.lang.String.substring(String.java:1911)
    at com.jediterm.terminal.model.SelectionUtil.getSelectionText(SelectionUtil.java:69)
    at com.jediterm.terminal.ui.TerminalPanel.copySelection(TerminalPanel.java:359)
    at com.jediterm.terminal.ui.TerminalPanel.handleCopy(TerminalPanel.java:1187)
    at com.jediterm.terminal.ui.TerminalPanel.access$16(TerminalPanel.java:1184)
    at com.jediterm.terminal.ui.TerminalPanel$2.mouseDragged(TerminalPanel.java:156)
    at java.awt.AWTEventMulticaster.mouseDragged(AWTEventMulticaster.java:320)
```
