### PR TITLE
Fix bug introduced in d62c023bd75a1f55a69cc7a5e843178f5f2c3d8b

### DIFF
--- a/src-terminal/com/jediterm/terminal/model/TerminalLine.java
+++ b/src-terminal/com/jediterm/terminal/model/TerminalLine.java
@@ -162,7 +162,7 @@ public class TerminalLine {
       }
       if (dx + remaining < len) {
         //part that left after deleting count 
-        newEntries.add(new TextEntry(entry.getStyle(), entry.getText().subBuffer(dx + count, len - (dx + count))));
+        newEntries.add(new TextEntry(entry.getStyle(), entry.getText().subBuffer(dx + remaining, len - (dx + remaining))));
         remaining = 0;
       } else {
         remaining -= (len - dx);


### PR DESCRIPTION
Stack was:

``` java
2606340 [Connector-16.16.184.36:22] ERROR com.jediterm.terminal.TerminalStarter  - Caught exception in terminal thread
java.lang.IllegalStateException: Length can't be negative: -1
    at com.jediterm.terminal.model.CharBuffer.<init>(CharBuffer.java:31)
    at com.jediterm.terminal.model.CharBuffer.subBuffer(CharBuffer.java:87)
    at com.jediterm.terminal.model.TerminalLine.deleteCharacters(TerminalLine.java:165)
    at com.jediterm.terminal.model.LinesBuffer.deleteCharacters(LinesBuffer.java:145)
    at com.jediterm.terminal.model.TerminalTextBuffer.deleteCharacters(TerminalTextBuffer.java:141)
    at com.jediterm.terminal.model.JediTerminal.deleteCharacters(JediTerminal.java:421)
    at com.jediterm.terminal.emulator.JediEmulator.deleteCharacters(JediEmulator.java:685)
    at com.jediterm.terminal.emulator.JediEmulator.processControlSequence(JediEmulator.java:365)
    at com.jediterm.terminal.emulator.JediEmulator.processEscapeSequence(JediEmulator.java:105)
    at com.jediterm.terminal.emulator.JediEmulator.processChar(JediEmulator.java:78)
    at com.jediterm.terminal.DataStreamIteratingEmulator.next(DataStreamIteratingEmulator.java:36)
    at com.jediterm.terminal.TerminalStarter.start(TerminalStarter.java:57)
    at com.jediterm.terminal.ui.JediTermWidget$EmulatorTask.run(JediTermWidget.java:226)
    at java.lang.Thread.run(Unknown Source)
```
