### PR TITLE
Keypad cursor keys improvment

### DIFF
--- a/src-pty/com/jediterm/pty/PtyMain.java
+++ b/src-pty/com/jediterm/pty/PtyMain.java
@@ -80,7 +80,7 @@ public class PtyMain extends AbstractTerminalFrame {
 
     @Override
     public void write(byte[] bytes) throws IOException {
-      LOG.debug("Writing in OutputStream : " + Arrays.toString(bytes));
+      LOG.debug("Writing in OutputStream : " + Arrays.toString(bytes) + " " + new String(bytes));
       super.write(bytes);
     }
   }

--- a/src-terminal/com/jediterm/terminal/TerminalKeyEncoder.java
+++ b/src-terminal/com/jediterm/terminal/TerminalKeyEncoder.java
@@ -18,8 +18,8 @@ public class TerminalKeyEncoder {
 
   public TerminalKeyEncoder() {
     setAutoNewLine(false);
-    arrowKeysApplicationSequences();
-    keypadApplicationSequences();
+    arrowKeysAnsiCursorSequences();
+    keypadAnsiSequences();
     putCode(VK_BACK_SPACE, Ascii.DEL);
     putCode(VK_F1, ESC, 'O', 'P');
     putCode(VK_F2, ESC, 'O', 'Q');
@@ -58,38 +58,26 @@ public class TerminalKeyEncoder {
     putCode(VK_LEFT, ESC, '[', 'D');
   }
 
+  public void keypadApplicationSequences() {
+    putCode(VK_KP_DOWN, ESC, 'O', 'B'); //2
+    putCode(VK_KP_LEFT, ESC, 'O', 'D'); //4
+    putCode(VK_KP_RIGHT, ESC, 'O', 'C'); //6
+    putCode(VK_KP_UP, ESC, 'O', 'A'); //8
+  }
+
+  public void keypadAnsiSequences() {
+    putCode(VK_KP_DOWN, ESC, '[', 'B'); //2
+    putCode(VK_KP_LEFT, ESC, '[', 'D'); //4
+    putCode(VK_KP_RIGHT, ESC, '[', 'C'); //6
+    putCode(VK_KP_UP, ESC, '[', 'A'); //8
+  }
+
   void putCode(final int code, final int... bytesAsInt) {
     myKeyCodes.put(code, CharacterUtils.makeCode(bytesAsInt));
   }
 
   public byte[] getCode(final int key) {
     return myKeyCodes.get(key);
-  }
-
-  public void keypadApplicationSequences() {
-    //0
-    //1
-    putCode(VK_KP_DOWN, ESC, '[', 'B'); //2
-    //3
-    putCode(VK_KP_LEFT, ESC, '[', 'D'); //4
-    //5
-    putCode(VK_KP_RIGHT, ESC, '[', 'C'); //6
-    //7
-    putCode(VK_KP_UP, ESC, '[', 'A'); //8
-    //9
-  }
-
-  public void normalKeypad() {
-    //0
-    //1
-    putCode(VK_KP_DOWN, 2); //2
-    //3
-    putCode(VK_KP_LEFT, 4); //4
-    //5
-    putCode(VK_KP_RIGHT, 6); //6
-    //7
-    putCode(VK_KP_UP, 8); //8
-    //9
   }
 
   public void setAutoNewLine(boolean enabled) {

--- a/src-terminal/com/jediterm/terminal/model/JediTerminal.java
+++ b/src-terminal/com/jediterm/terminal/model/JediTerminal.java
@@ -384,7 +384,7 @@ public class JediTerminal implements Terminal, TerminalMouseListener, TerminalCo
     if (enabled) {
       myTerminalKeyEncoder.keypadApplicationSequences();
     } else {
-      myTerminalKeyEncoder.normalKeypad();
+      myTerminalKeyEncoder.keypadAnsiSequences();
     }
   }
 

--- a/src-terminal/com/jediterm/terminal/ui/AbstractTerminalFrame.java
+++ b/src-terminal/com/jediterm/terminal/ui/AbstractTerminalFrame.java
@@ -151,6 +151,7 @@ public abstract class AbstractTerminalFrame {
     frame.getContentPane().add("Center", myTerminal.getComponent());
 
     frame.pack();
+    frame.setLocationByPlatform(true);
     frame.setVisible(true);
 
     frame.setResizable(true);
@@ -198,6 +199,7 @@ public abstract class AbstractTerminalFrame {
 
         myBufferFrame.getContentPane().add(panel);
         myBufferFrame.pack();
+        myBufferFrame.setLocationByPlatform(true);
         myBufferFrame.setVisible(true);
         myBufferFrame.setSize(800, 600);
 


### PR DESCRIPTION
This makes the behavior of the keypad closer (ie. identical) to what is done in gnome-terminal and xterm:
- cursor keys (both arrows and keypad) are in normal mode at start-up
-  when "numlock" is disabled, arrows and keypad behaves strictly identically regarding normal/application mode
- numlock is used to switch from cursor keys to numeric keys, this is offered by Java (we receive either VK_KP_DOWN or VK_NUMPAD2)

Relevant documentation extract:
http://invisible-island.net/xterm/xterm.faq.html

> Initially, the terminal is in normal mode.
[...]
> Depending on the terminal type, the keypad(s) on the keyboard may switch modes along with the cursor keys, or have their own independent modes.

http://www.xfree86.org/current/ctlseqs.html#PC-Style%20Function%20Keys
>  Use the NumLock key to override the application mode. 

http://www.vt100.net/docs/vt510-rm/DECCKM