### PR TITLE
KeyEvent handling fix for JavaFX.	

### DIFF
--- a/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
@@ -1185,6 +1185,10 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
         return;
       }
 
+      // Swing in Javafx translation does not result in portable KeyEvent conversions. This predicate filters out
+      // solo modifiers.
+      if(keychar == CharacterUtils.NUL_CHAR && e.getModifiers() != 0) return;
+
       final byte[] code = myTerminalStarter.getCode(keycode);
       if (code != null) {
         myTerminalStarter.sendBytes(code);


### PR DESCRIPTION
The way Javafx converts KeyEvents for Swing means that single modifier key presses result in junk getting sent to the Pty. (^@ for Ctrl), after quite a bit of debugging I have found the expression below to work.