### PR TITLE
Support IPv6 when using JSchTtyConnector 

### DIFF
--- a/src-ssh/com/jediterm/ssh/SshMain.java
+++ b/src-ssh/com/jediterm/ssh/SshMain.java
@@ -2,7 +2,6 @@ package com.jediterm.ssh;
 
 import com.jediterm.ssh.jsch.JSchTtyConnector;
 import com.jediterm.terminal.TtyConnector;
-import com.jediterm.terminal.emulator.ColorPalette;
 import com.jediterm.terminal.ui.AbstractTerminalFrame;
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Level;

--- a/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
+++ b/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
@@ -3,6 +3,7 @@
  */
 package com.jediterm.ssh.jsch;
 
+import com.google.common.net.HostAndPort;
 import com.jcraft.jsch.*;
 import com.jediterm.terminal.Questioner;
 import com.jediterm.terminal.TtyConnector;
@@ -151,17 +152,16 @@ public class JSchTtyConnector implements TtyConnector {
       if (myHost == null || myHost.length() == 0) {
         continue;
       }
-      if (myHost.indexOf(':') != -1) {
-        final String portString = myHost.substring(myHost.indexOf(':') + 1);
-        try {
-          myPort = Integer.parseInt(portString);
-        }
-        catch (final NumberFormatException eee) {
-          q.showMessage("Could not parse port : " + portString);
-          myHost = q.questionVisible("host: ", myHost);
-          continue;
-        }
-        myHost = myHost.substring(0, myHost.indexOf(':'));
+
+      try {
+        HostAndPort hostAndPort = HostAndPort.fromString(myHost);
+        myHost = hostAndPort.getHostText();
+        // override myPort only if specified in the input
+        myPort = hostAndPort.getPortOrDefault(myPort);
+      } catch (IllegalArgumentException e) {
+        q.showMessage(e.getMessage());
+        myHost = q.questionVisible("host: ", myHost);
+        continue;
       }
 
       if (myUser == null) {

--- a/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
+++ b/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
@@ -138,7 +138,7 @@ public class JSchTtyConnector implements TtyConnector {
   private void getAuthDetails(Questioner q) {
     while (true) {
       if (myHost == null) {
-        myHost = q.questionVisible("host:", "localhost");
+        myHost = q.questionVisible("host: ", "localhost");
       }
       if (myHost == null || myHost.length() == 0) {
         continue;
@@ -150,13 +150,14 @@ public class JSchTtyConnector implements TtyConnector {
         }
         catch (final NumberFormatException eee) {
           q.showMessage("Could not parse port : " + portString);
+          myHost = q.questionVisible("host: ", myHost);
           continue;
         }
         myHost = myHost.substring(0, myHost.indexOf(':'));
       }
 
       if (myUser == null) {
-        myUser = q.questionVisible("user:", System.getProperty("user.name").toLowerCase());
+        myUser = q.questionVisible("user: ", System.getProperty("user.name").toLowerCase());
       }
       if (myUser == null || myUser.length() == 0) {
         continue;

--- a/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
+++ b/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
@@ -6,6 +6,7 @@ package com.jediterm.ssh.jsch;
 import com.jcraft.jsch.*;
 import com.jediterm.terminal.Questioner;
 import com.jediterm.terminal.TtyConnector;
+
 import org.apache.log4j.Logger;
 
 import java.awt.*;
@@ -15,13 +16,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class JSchTtyConnector implements TtyConnector {
   public static final Logger LOG = Logger.getLogger(JSchTtyConnector.class);
 
+  public static final int DEFAULT_PORT = 22;
+
   private InputStream myInputStream = null;
   private OutputStream myOutputStream = null;
   private Session mySession;
   private ChannelShell myChannelShell;
   private AtomicBoolean isInitiated = new AtomicBoolean(false);
 
-  private int myPort = 22;
+  private int myPort = DEFAULT_PORT;
 
   private String myUser = null;
   private String myHost = null;
@@ -37,7 +40,12 @@ public class JSchTtyConnector implements TtyConnector {
   }
 
   public JSchTtyConnector(String host, String user, String password) {
+    this(host, DEFAULT_PORT, user, password);
+  }
+
+  public JSchTtyConnector(String host, int port, String user, String password) {
     this.myHost = host;
+    this.myPort = port;
     this.myUser = user;
     this.myPassword = password;
   }


### PR DESCRIPTION
Hi there,

It is currently not possible to specify an IPv6 when using the JSchTtyConnector, because of the `host:port` parsing mechanism relying on the semicolon only (which is not enough when dealing with IPv6).

This PR delegates `host:port` parsing to Guava `HostAndPort`, which properly handle hostname, IPv4 and IPv6 and optional port number.
