### PR TITLE
Improve search UI

### DIFF
--- a/src-terminal/com/jediterm/terminal/SubstringFinder.java
+++ b/src-terminal/com/jediterm/terminal/SubstringFinder.java
@@ -61,7 +61,7 @@ public class SubstringFinder {
 
     if (myCurrentLength == myPattern.length() &&
             myCurrentHash == myPatternHash) {
-      FindResult.FindItem item = new FindResult.FindItem(myTokens, myFirstIndex, index);
+      FindResult.FindItem item = new FindResult.FindItem(myTokens, myFirstIndex, index, -1);
       if (myPattern.equals(myIgnoreCase ? item.toString().toLowerCase() : item.toString())) {
         myResult.patternMatched(myTokens, myFirstIndex, index);
         myCurrentHash = 0;
@@ -104,10 +104,14 @@ public class SubstringFinder {
       final int firstIndex;
       final int lastIndex;
 
-      private FindItem(ArrayList<TextToken> tokens, int firstIndex, int lastIndex) {
+      // index in the result list
+      final int index;
+
+      private FindItem(ArrayList<TextToken> tokens, int firstIndex, int lastIndex, int index) {
         this.tokens = Lists.newArrayList(tokens);
         this.firstIndex = firstIndex;
         this.lastIndex = lastIndex;
+        this.index = index;
       }
 
       public String toString() {
@@ -131,6 +135,11 @@ public class SubstringFinder {
         }
 
         return b.toString();
+      }
+
+      // index in the result list
+      public int getIndex() {
+        return index;
       }
 
       public Point getStart() {
@@ -160,7 +169,7 @@ public class SubstringFinder {
         put(tokens.get(tokens.size() - 1).buf, range);
       }
 
-      items.add(new FindItem(tokens, firstIndex, lastIndex));
+      items.add(new FindItem(tokens, firstIndex, lastIndex, items.size() + 1));
 
     }
 

--- a/src-terminal/com/jediterm/terminal/SubstringFinder.java
+++ b/src-terminal/com/jediterm/terminal/SubstringFinder.java
@@ -184,7 +184,7 @@ public class SubstringFinder {
         currentFindItem--;
       }
 
-      if (currentFindItem <= items.size()) {
+      if (currentFindItem >= 0 && currentFindItem <= items.size()) {
         return items.get(currentFindItem);
       } else {
         return null;

--- a/src-terminal/com/jediterm/terminal/SubstringFinder.java
+++ b/src-terminal/com/jediterm/terminal/SubstringFinder.java
@@ -82,7 +82,6 @@ public class SubstringFinder {
     return myIgnoreCase ? Character.toLowerCase(c) : c;
   }
 
-
   private int hashCodeForChar(char charAt) {
     return myPower * charHash(charAt);
   }
@@ -177,21 +176,25 @@ public class SubstringFinder {
       return items;
     }
 
-    public FindItem nextFindItem() {
-      if (currentFindItem == 0) {
-        currentFindItem = items.size() - 1;
-      } else {
-        currentFindItem--;
-      }
-
-      if (currentFindItem >= 0 && currentFindItem <= items.size()) {
-        return items.get(currentFindItem);
-      } else {
+    public FindItem prevFindItem() {
+      if (items.isEmpty()) {
         return null;
       }
+      currentFindItem++;
+      currentFindItem %= items.size();
+      return items.get(currentFindItem);
+    }
+
+    public FindItem nextFindItem() {
+      if (items.isEmpty()) {
+        return null;
+      }
+      currentFindItem--;
+      // modulo can be negative in Java: add items.size() to ensure positive
+      currentFindItem = (currentFindItem + items.size()) % items.size();
+      return items.get(currentFindItem);
     }
   }
-
 
   private static class TextToken {
     final CharBuffer buf;

--- a/src-terminal/com/jediterm/terminal/ui/JediTermWidget.java
+++ b/src-terminal/com/jediterm/terminal/ui/JediTermWidget.java
@@ -45,7 +45,7 @@ public class JediTermWidget extends JPanel implements TerminalSession, TerminalW
   private TtyConnector myTtyConnector;
   private TerminalStarter myTerminalStarter;
   private Thread myEmuThread;
-  private final SettingsProvider mySettingsProvider;
+  protected final SettingsProvider mySettingsProvider;
   private TerminalActionProvider myNextActionProvider;
   private JLayeredPane myInnerPanel;
 

--- a/src-terminal/com/jediterm/terminal/ui/JediTermWidget.java
+++ b/src-terminal/com/jediterm/terminal/ui/JediTermWidget.java
@@ -344,14 +344,15 @@ public class JediTermWidget extends JPanel implements TerminalSession, TerminalW
     return myTerminalStarter;
   }
   
-  private class SearchPanel extends JPanel implements SearchComponent {
+  public class SearchPanel extends JPanel implements SearchComponent {
 
     private final JTextField myTextField = new JTextField();
     private final JLabel label = new JLabel();
-    private final JButton prev = new BasicArrowButton(SwingConstants.SOUTH);
-    private final JButton next = new BasicArrowButton(SwingConstants.NORTH);
+    private final JButton prev;
+    private final JButton next;
 
     public SearchPanel() {
+      next = createNextButton();
       next.addActionListener(new ActionListener() {
         @Override
         public void actionPerformed(ActionEvent e) {
@@ -359,6 +360,7 @@ public class JediTermWidget extends JPanel implements TerminalSession, TerminalW
         }
       });
 
+      prev = createPrevButton();
       prev.addActionListener(new ActionListener() {
         @Override
         public void actionPerformed(ActionEvent e) {
@@ -392,6 +394,14 @@ public class JediTermWidget extends JPanel implements TerminalSession, TerminalW
       add(prev);
 
       setOpaque(true);
+    }
+
+    protected JButton createNextButton() {
+      return new BasicArrowButton(SwingConstants.NORTH);
+    }
+
+    protected JButton createPrevButton() {
+      return new BasicArrowButton(SwingConstants.SOUTH);
     }
 
     private void nextFindResultItem() {

--- a/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
@@ -320,9 +320,17 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
     repaint();
   }
 
+  public void selectPrevFindResultItem() {
+    selectPrevOrNextFindResultItem(false);
+  }
+
   public void selectNextFindResultItem() {
+    selectPrevOrNextFindResultItem(true);
+  }
+
+  protected void selectPrevOrNextFindResultItem(boolean next) {
     if (myFindResult != null) {
-      SubstringFinder.FindResult.FindItem item = myFindResult.nextFindItem();
+      SubstringFinder.FindResult.FindItem item = next ? myFindResult.nextFindItem() : myFindResult.prevFindItem();
       if (item != null) {
         mySelection = new TerminalSelection(new Point(item.getStart().x, item.getStart().y - myTerminalTextBuffer.getHistoryLinesCount()),
                 new Point(item.getEnd().x, item.getEnd().y - myTerminalTextBuffer.getHistoryLinesCount()));

--- a/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/src-terminal/com/jediterm/terminal/ui/TerminalPanel.java
@@ -5,6 +5,7 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
 import com.jediterm.terminal.*;
+import com.jediterm.terminal.SubstringFinder.FindResult.FindItem;
 import com.jediterm.terminal.TextStyle.Option;
 import com.jediterm.terminal.emulator.ColorPalette;
 import com.jediterm.terminal.emulator.charset.CharacterSets;
@@ -14,6 +15,7 @@ import com.jediterm.terminal.model.*;
 import com.jediterm.terminal.ui.settings.SettingsProvider;
 import com.jediterm.terminal.util.CharUtils;
 import com.jediterm.terminal.util.Pair;
+
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -21,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+
 import java.awt.*;
 import java.awt.datatransfer.*;
 import java.awt.event.*;
@@ -320,15 +323,19 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
     repaint();
   }
 
-  public void selectPrevFindResultItem() {
-    selectPrevOrNextFindResultItem(false);
+  public SubstringFinder.FindResult getFindResult() {
+    return myFindResult;
   }
 
-  public void selectNextFindResultItem() {
-    selectPrevOrNextFindResultItem(true);
+  public FindItem selectPrevFindResultItem() {
+    return selectPrevOrNextFindResultItem(false);
   }
 
-  protected void selectPrevOrNextFindResultItem(boolean next) {
+  public FindItem selectNextFindResultItem() {
+    return selectPrevOrNextFindResultItem(true);
+  }
+
+  protected FindItem selectPrevOrNextFindResultItem(boolean next) {
     if (myFindResult != null) {
       SubstringFinder.FindResult.FindItem item = next ? myFindResult.nextFindItem() : myFindResult.prevFindItem();
       if (item != null) {
@@ -340,8 +347,10 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
           myBoundedRangeModel.setValue(0);
         }
         repaint();
+        return item;
       }
     }
+    return null;
   }
 
   static class WeakRedrawTimer implements ActionListener {


### PR DESCRIPTION
This MR is focused on improving the search panel UI:

- next/previous button are added, and bind to VK_UP and VK_DOWN
- number of hits and current hit is displayed
- search panel does not overlap with scrollbar
- hits position are displayed in the scrollbar

Here is an example with the basic L&F, and one with our custom L&F:

![screenshot from 2016-04-20 16 53 52](https://cloud.githubusercontent.com/assets/3908084/14679126/d9d7a38a-0718-11e6-9094-75845e746678.png)

Comment are welcome!
