### PR TITLE
TabbedTerminalWidget improvments

### DIFF
--- a/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
+++ b/src-ssh/com/jediterm/ssh/jsch/JSchTtyConnector.java
@@ -54,7 +54,9 @@ public class JSchTtyConnector implements TtyConnector {
   public void resize(Dimension termSize, Dimension pixelSize) {
     myPendingTermSize = termSize;
     myPendingPixelSize = pixelSize;
-    if (myChannelShell != null) resizeImmediately();
+    if (myChannelShell != null) {
+      resizeImmediately();
+    }
   }
 
   private void resizeImmediately() {
@@ -70,7 +72,6 @@ public class JSchTtyConnector implements TtyConnector {
     if (mySession != null) {
       mySession.disconnect();
       mySession = null;
-      myChannelShell = null;
       myInputStream = null;
       myOutputStream = null;
     }

--- a/src-terminal/com/jediterm/terminal/ui/JediTermWidget.java
+++ b/src-terminal/com/jediterm/terminal/ui/JediTermWidget.java
@@ -272,16 +272,16 @@ public class JediTermWidget extends JPanel implements TerminalSession, TerminalW
             myInnerPanel.remove(component);
             myInnerPanel.revalidate();
             myInnerPanel.repaint();
-            myInnerPanel.requestFocus();
             myFindComponent = null;
             myTerminalPanel.setFindResult(null);
+            myTerminalPanel.requestFocusInWindow();
           } else {
             super.keyPressed(keyEvent);
           }
         }
       });
     } else {
-      myFindComponent.getComponent().requestFocus();
+      myFindComponent.getComponent().requestFocusInWindow();
     }
   }
 

--- a/src-terminal/com/jediterm/terminal/ui/TabbedTerminalWidget.java
+++ b/src-terminal/com/jediterm/terminal/ui/TabbedTerminalWidget.java
@@ -56,7 +56,7 @@ public class TabbedTerminalWidget extends JPanel implements TerminalWidget, Term
   @Override
   public TerminalSession createTerminalSession(final TtyConnector ttyConnector) {
     final JediTermWidget terminal = createInnerTerminalWidget(mySettingsProvider);
-    terminal.setTtyConnector(ttyConnector);
+    terminal.createTerminalSession(ttyConnector);
     terminal.setNextProvider(this);
 
     new TtyConnectorWaitFor(ttyConnector, Executors.newSingleThreadExecutor()).setTerminationCallback(new Predicate<Integer>() {

--- a/src-terminal/com/jediterm/terminal/ui/TabbedTerminalWidget.java
+++ b/src-terminal/com/jediterm/terminal/ui/TabbedTerminalWidget.java
@@ -58,15 +58,7 @@ public class TabbedTerminalWidget extends JPanel implements TerminalWidget, Term
     terminal.createTerminalSession(ttyConnector);
     terminal.setNextProvider(this);
 
-    new TtyConnectorWaitFor(ttyConnector, Executors.newSingleThreadExecutor()).setTerminationCallback(new Predicate<Integer>() {
-      @Override
-      public boolean apply(Integer integer) {
-        if (mySettingsProvider.shouldCloseTabOnLogout(ttyConnector)) {
-          closeTab(terminal);
-        }
-        return true;
-      }
-    });
+    setupTtyConnectorWaitFor(ttyConnector, terminal);
 
     if (myTerminalPanelListener != null) {
       terminal.setTerminalPanelListener(myTerminalPanelListener);
@@ -97,6 +89,18 @@ public class TabbedTerminalWidget extends JPanel implements TerminalWidget, Term
 
   protected JediTermWidget createInnerTerminalWidget(TabbedSettingsProvider settingsProvider) {
     return new JediTermWidget(settingsProvider);
+  }
+
+  protected void setupTtyConnectorWaitFor(final TtyConnector ttyConnector, final JediTermWidget widget) {
+    new TtyConnectorWaitFor(ttyConnector, Executors.newSingleThreadExecutor()).setTerminationCallback(new Predicate<Integer>() {
+      @Override
+      public boolean apply(Integer integer) {
+        if (mySettingsProvider.shouldCloseTabOnLogout(ttyConnector)) {
+          closeTab(widget);
+        }
+        return true;
+      }
+    });
   }
 
   private void addTab(JediTermWidget terminal, TerminalTabs tabs) {

--- a/src-terminal/com/jediterm/terminal/ui/TabbedTerminalWidget.java
+++ b/src-terminal/com/jediterm/terminal/ui/TabbedTerminalWidget.java
@@ -531,6 +531,8 @@ public class TabbedTerminalWidget extends JPanel implements TerminalWidget, Term
       for (int i = 0; i < myTabs.getTabCount(); i++) {
         getTerminalPanel(i).setTerminalPanelListener(terminalPanelListener);
       }
+    } else if (myTermWidget!= null) {
+      myTermWidget.setTerminalPanelListener(terminalPanelListener);
     }
     myTerminalPanelListener = terminalPanelListener;
   }

--- a/src-terminal/com/jediterm/terminal/ui/TabbedTerminalWidget.java
+++ b/src-terminal/com/jediterm/terminal/ui/TabbedTerminalWidget.java
@@ -8,7 +8,6 @@ import com.jediterm.terminal.RequestOrigin;
 import com.jediterm.terminal.TerminalDisplay;
 import com.jediterm.terminal.TtyConnector;
 import com.jediterm.terminal.TtyConnectorWaitFor;
-import com.jediterm.terminal.ui.settings.SettingsProvider;
 import com.jediterm.terminal.ui.settings.TabbedSettingsProvider;
 import com.jediterm.terminal.util.JTextFieldLimit;
 import org.jetbrains.annotations.NotNull;
@@ -63,20 +62,7 @@ public class TabbedTerminalWidget extends JPanel implements TerminalWidget, Term
       @Override
       public boolean apply(Integer integer) {
         if (mySettingsProvider.shouldCloseTabOnLogout(ttyConnector)) {
-          if (myTabs != null) {
-            SwingUtilities.invokeLater(new Runnable() {
-              @Override
-              public void run() {
-                removeTab(terminal);
-              }
-            });
-          }
-          else {
-            if (myTermWidget == terminal) {
-              myTermWidget = null;
-            }
-          }
-          fireTabClosed(terminal);
+          closeTab(terminal);
         }
         return true;
       }
@@ -109,7 +95,7 @@ public class TabbedTerminalWidget extends JPanel implements TerminalWidget, Term
     return terminal;
   }
 
-  protected JediTermWidget createInnerTerminalWidget(SettingsProvider settingsProvider) {
+  protected JediTermWidget createInnerTerminalWidget(TabbedSettingsProvider settingsProvider) {
     return new JediTermWidget(settingsProvider);
   }
 
@@ -198,22 +184,24 @@ public class TabbedTerminalWidget extends JPanel implements TerminalWidget, Term
     return new TabComponent(tabs, terminal);
   }
 
-  private void close(JediTermWidget terminal) {
+  public void closeTab(final JediTermWidget terminal) {
     if (terminal != null) {
-      terminal.close();
       if (myTabs != null) {
-        removeTab(terminal);
-      }
-      else {
+          SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+              removeTab(terminal);
+            }
+          });
+      } else if (myTermWidget == terminal) {
         myTermWidget = null;
       }
-      fireTabClosed(terminal);
     }
+    fireTabClosed(terminal);
   }
 
-
   public void closeCurrentSession() {
-    close(getCurrentSession());
+    closeTab(getCurrentSession());
   }
 
   public void dispose() {
@@ -563,7 +551,7 @@ public class TabbedTerminalWidget extends JPanel implements TerminalWidget, Term
   @Nullable
   private JediTermWidget getTerminalPanel(int index) {
     if (index < myTabs.getTabCount() && index >= 0) {
-      return (JediTermWidget)myTabs.getComponentAt(index);
+      return (JediTermWidget) myTabs.getComponentAt(index);
     }
     else {
       return null;

--- a/src-terminal/com/jediterm/terminal/ui/TabbedTerminalWidget.java
+++ b/src-terminal/com/jediterm/terminal/ui/TabbedTerminalWidget.java
@@ -123,7 +123,7 @@ public class TabbedTerminalWidget extends JPanel implements TerminalWidget, Term
     tabs.addTab(name,
                 terminal);
 
-    tabs.setTabComponentAt(tabs.getTabCount() - 1, new TabComponent(tabs, terminal));
+    tabs.setTabComponentAt(tabs.getTabCount() - 1, createTabComponent(tabs, terminal));
     tabs.setSelectedComponent(terminal);
   }
 
@@ -192,6 +192,10 @@ public class TabbedTerminalWidget extends JPanel implements TerminalWidget, Term
 
   protected TerminalTabs createTabbedPane() {
     return new TerminalTabsImpl();
+  }
+
+  protected Component createTabComponent(TerminalTabs tabs, JediTermWidget terminal) {
+    return new TabComponent(tabs, terminal);
   }
 
   private void close(JediTermWidget terminal) {
@@ -514,6 +518,9 @@ public class TabbedTerminalWidget extends JPanel implements TerminalWidget, Term
     }
   }
 
+  public TerminalTabs getTerminalTabs() {
+    return myTabs;
+  }
 
   @Override
   public JComponent getComponent() {

--- a/src-terminal/com/jediterm/terminal/ui/TerminalTabsImpl.java
+++ b/src-terminal/com/jediterm/terminal/ui/TerminalTabsImpl.java
@@ -11,7 +11,7 @@ import java.awt.event.ContainerListener;
  * @author traff
  */
 public class TerminalTabsImpl implements TerminalTabs {
-  private JTabbedPane myTabbedPane = new JTabbedPane();
+  protected JTabbedPane myTabbedPane = new JTabbedPane();
 
   @Override
   public int getTabCount() {


### PR DESCRIPTION
This PR widen overriding possibilities for tabs components, and fixes 2 bugs when using `TabbedTerminalWidget`:
- terminal panel was not getting focus when closing search panel
- when only one tab is open, it was not getting `terminalPanelListener` set