### PR TITLE
Propose ChannelExec along with ChannelShell

### DIFF
--- a/src-ssh/com/jediterm/ssh/SshMain.java
+++ b/src-ssh/com/jediterm/ssh/SshMain.java
@@ -1,8 +1,10 @@
 package com.jediterm.ssh;
 
+import com.jediterm.ssh.jsch.JSchShellTtyConnector;
 import com.jediterm.ssh.jsch.JSchTtyConnector;
 import com.jediterm.terminal.TtyConnector;
 import com.jediterm.terminal.ui.AbstractTerminalFrame;
+
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -20,7 +22,7 @@ public class SshMain extends AbstractTerminalFrame {
 
   @Override
   public TtyConnector createTtyConnector() {
-    return new JSchTtyConnector();
+    return new JSchShellTtyConnector();
   }
 
 }

--- a/src-ssh/com/jediterm/ssh/jsch/JSchExecTtyConnector.java
+++ b/src-ssh/com/jediterm/ssh/jsch/JSchExecTtyConnector.java
@@ -1,0 +1,37 @@
+package com.jediterm.ssh.jsch;
+
+import com.jcraft.jsch.ChannelExec;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+
+public class JSchExecTtyConnector extends JSchTtyConnector<ChannelExec> {
+
+  public JSchExecTtyConnector() {
+  }
+
+  public JSchExecTtyConnector(String host, String user, String password) {
+    super(host, DEFAULT_PORT, user, password);
+  }
+
+  public JSchExecTtyConnector(String host, int port, String user, String password) {
+    super(host, port, user, password);
+  }
+
+  @Override
+  protected ChannelExec openChannel(Session session) throws JSchException {
+    return (ChannelExec) session.openChannel("exec");
+  }
+
+  @Override
+  protected void configureChannelShell(ChannelExec channel) {
+    String lang = System.getenv().get("LANG");
+    channel.setEnv("LANG", lang != null ? lang : "en_US.UTF-8");
+    channel.setPtyType("xterm");
+  }
+
+  @Override
+  protected void setPtySize(ChannelExec channel, int col, int row, int wp, int hp) {
+    channel.setPtySize(col, row, wp, hp);
+  }
+
+}

--- a/src-ssh/com/jediterm/ssh/jsch/JSchShellTtyConnector.java
+++ b/src-ssh/com/jediterm/ssh/jsch/JSchShellTtyConnector.java
@@ -1,0 +1,37 @@
+package com.jediterm.ssh.jsch;
+
+import com.jcraft.jsch.ChannelShell;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+
+public class JSchShellTtyConnector extends JSchTtyConnector<ChannelShell> {
+
+  public JSchShellTtyConnector() {
+  }
+
+  public JSchShellTtyConnector(String host, String user, String password) {
+    super(host, DEFAULT_PORT, user, password);
+  }
+
+  public JSchShellTtyConnector(String host, int port, String user, String password) {
+    super(host, port, user, password);
+  }
+
+  @Override
+  protected ChannelShell openChannel(Session session) throws JSchException {
+    return (ChannelShell) session.openChannel("shell");
+  }
+
+  @Override
+  protected void configureChannelShell(ChannelShell channel) {
+    String lang = System.getenv().get("LANG");
+    channel.setEnv("LANG", lang != null ? lang : "en_US.UTF-8");
+    channel.setPtyType("xterm");
+  }
+
+  @Override
+  protected void setPtySize(ChannelShell channel, int col, int row, int wp, int hp) {
+    channel.setPtySize(col, row, wp, hp);
+  }
+
+}


### PR DESCRIPTION
For some reason, I need to use a `ChannelExec` (run one command and close the session) instead of a `ChannelShell` (interactive shell).

Both `ChannelExec` and `ChannelShell` extends `ChannelSession` and all methods we use are visible in `ChannelSession` (`setPtyType()`, `setPtySize()`...), so it should have been trivial. The problem is that `ChannelSession` is package-protected, so there is *no way* to reference it from the outside of JSCH library. It looks to me to be an obvious visibility issue, which is common in this library (see https://techtavern.wordpress.com/2008/09/30/about-jsch-open-source-project/). It looks to be hard to contribute to JSCH, so I prefer to fix it on our side.

Because `ChannelSession` is not visible, I had to extract some parts of `JSchTtyConnector` and duplicate them into `JSchExecTtyConnector` and `JSchShellTtyConnector`. Not very nice, but easy enough; not sure how we can do better...