### PR TITLE
Fix some AIOOB when history max size is smaller than terminal height

### DIFF
--- a/src-terminal/com/jediterm/terminal/model/LinesBuffer.java
+++ b/src-terminal/com/jediterm/terminal/model/LinesBuffer.java
@@ -19,6 +19,7 @@ public class LinesBuffer {
 
   public static final int DEFAULT_MAX_LINES_COUNT = 1000;
 
+  // negative number means no limit
   private int myBufferMaxLinesCount = DEFAULT_MAX_LINES_COUNT;
 
   private ArrayList<TerminalLine> myLines = Lists.newArrayList();
@@ -58,7 +59,7 @@ public class LinesBuffer {
   }
 
   private synchronized void addLine(@NotNull TerminalLine line) {
-    if (myLines.size() >= myBufferMaxLinesCount) {
+    if (myBufferMaxLinesCount > 0 && myLines.size() >= myBufferMaxLinesCount) {
       removeTopLines(1);
     }
 
@@ -70,7 +71,11 @@ public class LinesBuffer {
   }
 
   public synchronized void removeTopLines(int count) {
-    myLines = Lists.newArrayList(myLines.subList(count, myLines.size()));
+    if (count >= myLines.size()) { // remove all lines
+      myLines = Lists.newArrayList();
+    } else {
+      myLines = Lists.newArrayList(myLines.subList(count, myLines.size()));
+    }
   }
 
   public String getLineText(int row) {
@@ -187,10 +192,20 @@ public class LinesBuffer {
   }
 
   public synchronized void addLines(@NotNull List<TerminalLine> lines) {
-    int count = myLines.size() + lines.size();
-    if (count >= myBufferMaxLinesCount) {
-      removeTopLines(count - myBufferMaxLinesCount);
+    if (myBufferMaxLinesCount > 0) {
+      // adding more lines than max size
+      if (lines.size() >= myBufferMaxLinesCount) {
+        int index = lines.size() - myBufferMaxLinesCount;
+        myLines = Lists.newArrayList(lines.subList(index, lines.size()));
+        return;
+      }
+
+      int count = myLines.size() + lines.size();
+      if (count >= myBufferMaxLinesCount) {
+        removeTopLines(count - myBufferMaxLinesCount);
+      }
     }
+
     myLines.addAll(lines);
   }
 

--- a/src-terminal/com/jediterm/terminal/model/TerminalTextBuffer.java
+++ b/src-terminal/com/jediterm/terminal/model/TerminalTextBuffer.java
@@ -62,12 +62,17 @@ public class TerminalTextBuffer {
     myHeight = height;
     myHistoryLinesCount = historyLinesCount;
 
-    myScreenBuffer = createLinesBuffer();
-    myHistoryBuffer = createLinesBuffer();
+    myScreenBuffer = createScreenBuffer();
+    myHistoryBuffer = createHistoryBuffer();
   }
 
   @NotNull
-  private LinesBuffer createLinesBuffer() {
+  private LinesBuffer createScreenBuffer() {
+    return new LinesBuffer(-1);
+  }
+
+  @NotNull
+  private LinesBuffer createHistoryBuffer() {
     return new LinesBuffer(myHistoryLinesCount);
   }
 
@@ -79,7 +84,6 @@ public class TerminalTextBuffer {
 
     final int newWidth = pendingResize.width;
     final int newHeight = pendingResize.height;
-    final int textLinesCountOld = myScreenBuffer.getLineCount();
 
     final int oldHeight = myHeight;
 
@@ -342,17 +346,17 @@ public class TerminalTextBuffer {
       if (!myUsingAlternateBuffer) {
         myScreenBufferBackup = myScreenBuffer;
         myHistoryBufferBackup = myHistoryBuffer;
-        myScreenBuffer = createLinesBuffer();
-        myHistoryBuffer = createLinesBuffer();
+        myScreenBuffer = createScreenBuffer();
+        myHistoryBuffer = createHistoryBuffer();
         myUsingAlternateBuffer = true;
       }
     } else {
       if (myUsingAlternateBuffer) {
         myScreenBuffer = myScreenBufferBackup;
         myHistoryBuffer = myHistoryBufferBackup;
+        myScreenBufferBackup = createScreenBuffer();
+        myHistoryBufferBackup = createHistoryBuffer();
         myUsingAlternateBuffer = false;
-        myScreenBufferBackup = createLinesBuffer();
-        myHistoryBufferBackup = createLinesBuffer();
       }
     }
     fireModelChangeEvent();


### PR DESCRIPTION
When scroll history max size (defined by `UserSettingsProvider.getBufferMaxLinesCount()` is smaller than current terminal height, lines operations fail with AIOOB.

This MR remove the size limit from `myScreenBuffer`, already bound to display size, and fix lines operations when `myHistoryBuffer` is smaller than `myScreenBuffer`.