### PR TITLE
bugfix: show a specific area if scrolled manually and output is printed fast enough

### DIFF
--- a/terminal/src/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/terminal/src/com/jediterm/terminal/ui/TerminalPanel.java
@@ -1222,7 +1222,7 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
   }
 
   public void scrollArea(final int scrollRegionTop, final int scrollRegionSize, int dy) {
-    scrollDy.set(dy);
+    scrollDy.addAndGet(dy);
     mySelection = null;
   }
 


### PR DESCRIPTION
"Fast enough" means faster than one line between com.jediterm.terminal.ui.TerminalPanel.WeakRedrawTimer.actionPerformed calls (by default it's 1000/50=20ms)