### PR TITLE
fix VtEmulatorTest.testTest3_Characters_1, fix potential ArrayOutOfBoundsException

### DIFF
--- a/terminal/src/com/jediterm/terminal/model/JediTerminal.java
+++ b/terminal/src/com/jediterm/terminal/model/JediTerminal.java
@@ -1061,12 +1061,6 @@ public class JediTerminal implements Terminal, TerminalMouseListener, TerminalCo
         buf[j] = str[i];
         int codePoint = Character.codePointAt(str, i);
         boolean doubleWidthCharacter = CharUtils.isDoubleWidthCharacter(codePoint, myDisplay.ambiguousCharsAreDoubleWidth());
-        if (Character.charCount(Character.codePointAt(str, i)) == 2) {
-          // Copy the next character too before adding the DWC.
-          i++;
-          j++;
-          buf[j] = str[i];
-        }
         if (doubleWidthCharacter) {
           j++;
           buf[j] = CharUtils.DWC;

--- a/terminal/src/com/jediterm/terminal/util/CharUtils.java
+++ b/terminal/src/com/jediterm/terminal/util/CharUtils.java
@@ -288,7 +288,6 @@ public class CharUtils {
     return 1 +
             ((ucs >= 0x1100 &&
                     (ucs <= 0x115f ||                    /* Hangul Jamo init. consonants */
-                            isEmoji(ucs) ||
                             ucs == 0x2329 || ucs == 0x232a ||
                             (ucs >= 0x2e80 && ucs <= 0xa4cf &&
                                     ucs != 0x303f) ||                  /* CJK ... Yi */
@@ -300,22 +299,5 @@ public class CharUtils {
                             (ucs >= 0xffe0 && ucs <= 0xffe6) ||
                             (ucs >= 0x20000 && ucs <= 0x2fffd) ||
                             (ucs >= 0x30000 && ucs <= 0x3fffd))) ? 1 : 0);
-  }
-
-  private static boolean isEmoji(int ucs) {
-    // There is still more work to do here in order to support the flags, which use combining characters.
-    Character.UnicodeBlock block = Character.UnicodeBlock.of(ucs);
-    return (block != null) && (
-        block.equals(Character.UnicodeBlock.DINGBATS) ||
-        block.equals(Character.UnicodeBlock.ENCLOSED_ALPHANUMERICS) ||
-        block.equals(Character.UnicodeBlock.ENCLOSED_ALPHANUMERIC_SUPPLEMENT) ||
-        block.equals(Character.UnicodeBlock.MISCELLANEOUS_SYMBOLS) ||
-        block.equals(Character.UnicodeBlock.MISCELLANEOUS_SYMBOLS_AND_ARROWS) ||
-        block.equals(Character.UnicodeBlock.MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS) ||
-        block.equals(Character.UnicodeBlock.MISCELLANEOUS_TECHNICAL) ||
-        block.equals(Character.UnicodeBlock.ARROWS) ||
-        block.equals(Character.UnicodeBlock.SUPPLEMENTAL_ARROWS_A) ||
-        block.equals(Character.UnicodeBlock.SUPPLEMENTAL_ARROWS_B)
-    );
   }
 }


### PR DESCRIPTION
Previously, `CharUtils.isEmoji(9146)` returned `true`, though [9146](http://www.unicodemap.org/details/0x23BA/index.html) is not an emoji.

This commit partially reverts https://github.com/JetBrains/jediterm/commit/331a005d6793e52cefc9e2cec6774e62d5a546b1 which caused a few similar issues:
* https://youtrack.jetbrains.com/issue/IDEA-184778
* https://youtrack.jetbrains.com/issue/IDEA-185523
* https://youtrack.jetbrains.com/issue/IDEA-184513