### PR TITLE
IDEA-193879 IJ Terminal links are not clickable

### DIFF
--- a/terminal/src/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/terminal/src/com/jediterm/terminal/ui/TerminalPanel.java
@@ -338,7 +338,7 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
   @Nullable
   private HyperlinkStyle findHyperlink(Point p) {
     p = panelToCharCoords(p);
-    if (p.x >= 0 && p.y >= 0 && p.x < myTerminalTextBuffer.getWidth() && p.y <= myTerminalTextBuffer.getHeight()) {
+    if (p.x >= 0 && p.x < myTerminalTextBuffer.getWidth() && p.y <= myTerminalTextBuffer.getHeight()) {
       TextStyle style = myTerminalTextBuffer.getStyleAt(p.x, p.y);
       if (style instanceof HyperlinkStyle) {
         return (HyperlinkStyle) style;


### PR DESCRIPTION
when output hides from viewport (regression)