### PR TITLE
Pulled getPreferredFocusableComponent up to TerminalWidget interface.…

### DIFF
--- a/terminal/src/com/jediterm/terminal/ui/TabbedTerminalWidget.java
+++ b/terminal/src/com/jediterm/terminal/ui/TabbedTerminalWidget.java
@@ -317,10 +317,6 @@ public class TabbedTerminalWidget extends JPanel implements TerminalWidget, Term
     myCreateNewSessionAction.apply(this);
   }
 
-  public Component getFocusableComponent() {
-    return myTabs != null ? myTabs.getComponent() : myTermWidget != null ? myTermWidget : this;
-  }
-
   public static class TabRenamer {
 
     public interface RenameCallBack {
@@ -517,6 +513,15 @@ public class TabbedTerminalWidget extends JPanel implements TerminalWidget, Term
   @Override
   public JComponent getComponent() {
     return myPanel;
+  }
+
+  public Component getFocusableComponent() {
+    return myTabs != null ? myTabs.getComponent() : myTermWidget != null ? myTermWidget : this;
+  }
+
+  @Override
+  public Component getPreferredFocusableComponent() {
+    return getFocusableComponent();
   }
 
   @Override

--- a/terminal/src/com/jediterm/terminal/ui/TabbedTerminalWidget.java
+++ b/terminal/src/com/jediterm/terminal/ui/TabbedTerminalWidget.java
@@ -515,12 +515,12 @@ public class TabbedTerminalWidget extends JPanel implements TerminalWidget, Term
     return myPanel;
   }
 
-  public Component getFocusableComponent() {
+  public JComponent getFocusableComponent() {
     return myTabs != null ? myTabs.getComponent() : myTermWidget != null ? myTermWidget : this;
   }
 
   @Override
-  public Component getPreferredFocusableComponent() {
+  public JComponent getPreferredFocusableComponent() {
     return getFocusableComponent();
   }
 

--- a/terminal/src/com/jediterm/terminal/ui/TerminalWidget.java
+++ b/terminal/src/com/jediterm/terminal/ui/TerminalWidget.java
@@ -14,7 +14,7 @@ public interface TerminalWidget {
 
   JComponent getComponent();
 
-  default Component getPreferredFocusableComponent() {
+  default JComponent getPreferredFocusableComponent() {
     return getComponent();
   }
 

--- a/terminal/src/com/jediterm/terminal/ui/TerminalWidget.java
+++ b/terminal/src/com/jediterm/terminal/ui/TerminalWidget.java
@@ -14,6 +14,10 @@ public interface TerminalWidget {
 
   JComponent getComponent();
 
+  default Component getPreferredFocusableComponent() {
+    return getComponent();
+  }
+
   boolean canOpenSession();
 
   void setTerminalPanelListener(TerminalPanelListener terminalPanelListener);


### PR DESCRIPTION
… The old method (getFocusableComponent) is left for time being for backwards compatibility.