### PR TITLE
Fix line spacing

### DIFF
--- a/terminal/src/com/jediterm/terminal/ui/JediTermWidget.java
+++ b/terminal/src/com/jediterm/terminal/ui/JediTermWidget.java
@@ -413,7 +413,7 @@ public class JediTermWidget extends JPanel implements TerminalSession, TerminalW
 
       myTextField.setPreferredSize(new Dimension(
               myTerminalPanel.myCharSize.width * 30,
-              myTerminalPanel.myCharSize.height + 3));
+              myTerminalPanel.myLineHeight + 3));
       myTextField.setEditable(true);
 
       updateLabel(null);


### PR DESCRIPTION
Current implementation has these deficiencies:
  - box drawing characters always have vertical gap
  - line height doesn't scale proportionally to line spacing

After proposed changes:
  - no gap between box drawing characters at line spacing 1.0
  - line height increases proportionally with line spacing setting
  - pixel-to-pixel consistency with IDEA editor window

I'm not able to test changes on OS X. Previous code comment says that there are problems with certain emoji characters. If the problem still exists, I think it should be dealt with by fitting individual characters into terminal cell.

At line spacing > 1.0 there is vertical gap between box drawing characters (same as current implementation). Gnome-terminal is able eliminate those gaps, implementing this could be a further improvement to jediterm.