### PR TITLE
pack sources of terminal module to jediterm-pty-VERSION-sources.jar

### DIFF
--- a/pty/build.gradle
+++ b/pty/build.gradle
@@ -53,9 +53,11 @@ jar {
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
+    evaluationDependsOn(':terminal')
     baseName "jediterm-pty"
     classifier "sources"
     from sourceSets.main.allSource
+    from project(':terminal').sourceSets.main.allSource
 }
 
 artifacts {


### PR DESCRIPTION
Now it works via accessing source roots of `terminal` sub-project.
Thanks to @vladsoroka for the help in troubleshooting Gradle dependencies evaluation.