### PR TITLE
respect headless mode (IDEA-158077)

### DIFF
--- a/terminal/src/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/terminal/src/com/jediterm/terminal/ui/TerminalPanel.java
@@ -156,7 +156,9 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Clipbo
   public void init() {
     initFont();
 
-    setUpClipboard();
+    if (!Boolean.getBoolean("java.awt.headless")) {
+      setUpClipboard();
+    }
 
     setPreferredSize(new Dimension(getPixelWidth(), getPixelHeight()));
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/IDEA-158077
Though JBTerminalWidget shouldn't be ever created in headless mode, let's not fail test. Maybe it'd be better to log a warning.