### PR TITLE
fix cursor shape where 0 follows an escape code

### DIFF
--- a/terminal/src/com/jediterm/terminal/emulator/JediEmulator.java
+++ b/terminal/src/com/jediterm/terminal/emulator/JediEmulator.java
@@ -622,6 +622,7 @@ public class JediEmulator extends DataStreamIteratingEmulator {
   private boolean cursorShape(ControlSequence args) {
     myTerminal.cursorBackward(1);
     switch (args.getArg(0, 0)) {
+      case 0:
       case 1:
         myTerminal.cursorShape(CursorShape.BLINK_BLOCK);
         return true;


### PR DESCRIPTION
From the spec (https://vt100.net/docs/vt510-rm/DECSCUSR), it appears that the `0` should also be accepted as an escape sequence for changing the cursor shape.