### PR TITLE
Implement xterm OSC 11 query escape sequence.

### DIFF
--- a/terminal/src/com/jediterm/terminal/Terminal.java
+++ b/terminal/src/com/jediterm/terminal/Terminal.java
@@ -157,4 +157,6 @@ public interface Terminal {
   void setLinkUriFinished();
 
   void setBracketedPasteMode(boolean enabled);
+  
+  TerminalColor getWindowBackground();
 }

--- a/terminal/src/com/jediterm/terminal/TerminalColor.java
+++ b/terminal/src/com/jediterm/terminal/TerminalColor.java
@@ -1,5 +1,6 @@
 package com.jediterm.terminal;
 
+import com.google.common.base.Strings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -70,6 +71,17 @@ public class TerminalColor {
     return myColorIndex;
   }
 
+  public @NotNull String toHexString16() {
+    Color color = toAwtColor();
+
+    // (n * 0x101) converts the 8-bit number to 16 bits.
+    String red = Strings.padStart(Integer.toHexString(color.getRed() * 0x101), 4, '0');
+    String green = Strings.padStart(Integer.toHexString(color.getGreen() * 0x101), 4, '0');
+    String blue = Strings.padStart(Integer.toHexString(color.getBlue() * 0x101), 4, '0');
+    
+    return red + "/" + green + "/" + blue;
+  }
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;

--- a/terminal/src/com/jediterm/terminal/TerminalDisplay.java
+++ b/terminal/src/com/jediterm/terminal/TerminalDisplay.java
@@ -39,4 +39,6 @@ public interface TerminalDisplay {
   boolean ambiguousCharsAreDoubleWidth();
 
   default void setBracketedPasteMode(boolean enabled) {}
+  
+  TerminalColor getWindowBackground();
 }

--- a/terminal/src/com/jediterm/terminal/emulator/JediEmulator.java
+++ b/terminal/src/com/jediterm/terminal/emulator/JediEmulator.java
@@ -218,6 +218,14 @@ public class JediEmulator extends DataStreamIteratingEmulator {
           return true;
         }
         break;
+      case 11: // Background http://www.xfree86.org/4.5.0/ctlseqs.html
+        if ("?".equals(args.getStringAt(1))) { // Query
+          TerminalColor background = myTerminal.getWindowBackground();
+          String str = "\033]11;rgb:" + background.toHexString16() + "\007";
+          LOG.debug("Responding to OSC 11 query : " + str);
+          myTerminal.deviceStatusReport(str);
+        }
+        break;
     }
     return false;
   }

--- a/terminal/src/com/jediterm/terminal/model/JediTerminal.java
+++ b/terminal/src/com/jediterm/terminal/model/JediTerminal.java
@@ -255,6 +255,11 @@ public class JediTerminal implements Terminal, TerminalMouseListener, TerminalCo
   }
 
   @Override
+  public TerminalColor getWindowBackground() {
+    return myDisplay.getWindowBackground();
+  }
+
+  @Override
   public void backspace() {
     myCursorX -= 1;
     if (myCursorX < 0) {

--- a/terminal/src/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/terminal/src/com/jediterm/terminal/ui/TerminalPanel.java
@@ -921,6 +921,14 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Termin
     return myWindowTitle;
   }
 
+  @Override
+  public TerminalColor getWindowBackground() {
+    Color windowBackground = getBackground();
+    
+    // Return RGB color because we don't have palette information outside of TerminalPanel.
+    return new TerminalColor(windowBackground.getRed(), windowBackground.getGreen(), windowBackground.getBlue());
+  }
+
   protected int getInsetX() {
     return 4;
   }


### PR DESCRIPTION
This pull request implements the OSC 11 query escape sequence, `\e]11;?\a`.

The escape sequence asks the terminal to respond with the background color of the terminal window. This is supported in many popular terminal emulators, and is used by programs such as `vim` to determine an appropriate foreground text color.


## Implementation

I'm not very familiar with the code base, but I tired to avoid introducing unnecessary coupling.

1. By adding `getWindowBackground` to the `Terminal` and `TerminalDisplay` interfaces, the `JediEmulator` class is able to get the window background through `JediEmulator -> Terminal (impl JediTerminal) -> TerminalDisplay (impl TerminalPanel)` without having to expose any palette or TerminalDisplay information.

2. In the implementation of `getWindowBackground` in `TerminalPanel`, I create a new `TerminalColor` instead of re-using `myStyleState.getBackground()`. This prevents having to add more methods to get the palette as well, as an indexed `TerminalColor` will throw an exception when you try to get the RGB values from it.

