### PR TITLE
Parse DCS

### DIFF
--- a/terminal/src/com/jediterm/terminal/emulator/JediEmulator.java
+++ b/terminal/src/com/jediterm/terminal/emulator/JediEmulator.java
@@ -127,12 +127,19 @@ public class JediEmulator extends DataStreamIteratingEmulator {
       case 'O':
         terminal.singleShiftSelect(3); //Single Shift Select of G3 Character Set (SS3). This affects next character only.
         break;
+      case 'P': // Device Control String (DCS)
+        SystemCommandSequence command = new SystemCommandSequence(myDataStream);
+
+        if (!deviceControlString(command)) {
+          LOG.error("Error processing DCS: ESCP" + command.getSequenceString());
+        }
+        break;
       case ']': // Operating System Command (OSC)
         // xterm uses it to set parameters like windows title
-        final SystemCommandSequence command = new SystemCommandSequence(myDataStream);
+        command = new SystemCommandSequence(myDataStream);
 
         if (!operatingSystemCommand(command)) {
-          LOG.error("Error processing OSC " + command.getSequenceString());
+          LOG.error("Error processing OSC: ESC]" + command.getSequenceString());
         }
         break;
       case '6':
@@ -190,6 +197,10 @@ public class JediEmulator extends DataStreamIteratingEmulator {
       default:
         unsupported(ch);
     }
+  }
+
+  private boolean deviceControlString(SystemCommandSequence args) {
+    return false;
   }
 
   private boolean operatingSystemCommand(SystemCommandSequence args) {

--- a/terminal/src/com/jediterm/terminal/emulator/SystemCommandSequence.java
+++ b/terminal/src/com/jediterm/terminal/emulator/SystemCommandSequence.java
@@ -88,6 +88,11 @@ final class SystemCommandSequence {
   }
 
   public String getSequenceString() {
-    return mySequenceString.toString();
+    return mySequenceString.toString().replace("\u001b", "ESC")
+      .replace("\n", "\\n")
+      .replace("\r", "\\r")
+      .replace("\u0007", "BEL")
+      .replace(" ", "<S>")
+      .replace("\b", "\\b");
   }
 }


### PR DESCRIPTION
This PR doesn't add support for any device control strings, it only parses them and logs failure.
I think it's important to parse them, otherwise jediterm sees DCS, logs "Unsupported control characters: ESC  P" and continues interpreting the rest of DCS instead of ignoring it.