### PR TITLE
[typeahead] Fix alt+arrows predictions in zsh

### DIFF
--- a/JediTerm/src/main/kotlin/com/jediterm/app/JediTermMain.kt
+++ b/JediTerm/src/main/kotlin/com/jediterm/app/JediTermMain.kt
@@ -75,7 +75,7 @@ class JediTerm : AbstractTerminalFrame(), Disposable {
                 .setConsole(false)
                 .start()
 
-            return LoggingPtyProcessTtyConnector(process, charset)
+            return LoggingPtyProcessTtyConnector(process, charset, command.toList())
         } catch (e: Exception) {
             throw IllegalStateException(e)
         }
@@ -88,8 +88,8 @@ class JediTerm : AbstractTerminalFrame(), Disposable {
         return widget
     }
 
-    class LoggingPtyProcessTtyConnector(process: PtyProcess, charset: Charset) :
-        PtyProcessTtyConnector(process, charset), LoggingTtyConnector {
+    class LoggingPtyProcessTtyConnector(process: PtyProcess, charset: Charset, command: List<String>) :
+        PtyProcessTtyConnector(process, charset, command), LoggingTtyConnector {
         private val myDataChunks = Lists.newArrayList<CharArray>()
 
         @Throws(IOException::class)

--- a/pty/src/com/jediterm/pty/PtyProcessTtyConnector.java
+++ b/pty/src/com/jediterm/pty/PtyProcessTtyConnector.java
@@ -4,9 +4,11 @@ import com.jediterm.terminal.ProcessTtyConnector;
 import com.pty4j.PtyProcess;
 import com.pty4j.WinSize;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.awt.*;
+import java.awt.Dimension;
 import java.nio.charset.Charset;
+import java.util.List;
 
 /**
  * @author traff
@@ -15,7 +17,11 @@ public class PtyProcessTtyConnector extends ProcessTtyConnector {
   private final PtyProcess myProcess;
 
   public PtyProcessTtyConnector(@NotNull PtyProcess process, @NotNull Charset charset) {
-    super(process, charset);
+    this(process, charset, null);
+  }
+
+  public PtyProcessTtyConnector(@NotNull PtyProcess process, @NotNull Charset charset, @Nullable List<String> commandLine) {
+    super(process, charset, commandLine);
     myProcess = process;
   }
 

--- a/terminal/src/com/jediterm/terminal/ProcessTtyConnector.java
+++ b/terminal/src/com/jediterm/terminal/ProcessTtyConnector.java
@@ -3,12 +3,14 @@ package com.jediterm.terminal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.awt.*;
+import java.awt.Dimension;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author traff
@@ -20,13 +22,19 @@ public abstract class ProcessTtyConnector implements TtyConnector {
   protected final Charset myCharset;
   private Dimension myPendingTermSize;
   private final Process myProcess;
+  private final @Nullable List<String> myCommandLine;
 
   public ProcessTtyConnector(@NotNull Process process, @NotNull Charset charset) {
+    this(process, charset, null);
+  }
+
+  public ProcessTtyConnector(@NotNull Process process, @NotNull Charset charset, @Nullable List<String> commandLine) {
     myOutputStream = process.getOutputStream();
     myCharset = charset;
     myInputStream = process.getInputStream();
     myReader = new InputStreamReader(myInputStream, charset);
     myProcess = process;
+    myCommandLine = commandLine;
   }
 
   @NotNull
@@ -51,6 +59,10 @@ public abstract class ProcessTtyConnector implements TtyConnector {
 
   @Override
   public abstract String getName();
+
+  public @Nullable List<String> getCommandLine() {
+    return myCommandLine != null ? Collections.unmodifiableList(myCommandLine) : null;
+  }
 
   public int read(char[] buf, int offset, int length) throws IOException {
     return myReader.read(buf, offset, length);

--- a/terminal/src/com/jediterm/terminal/model/JediTermTypeAheadModel.java
+++ b/terminal/src/com/jediterm/terminal/model/JediTermTypeAheadModel.java
@@ -10,6 +10,7 @@ public class JediTermTypeAheadModel implements TypeAheadTerminalModel {
   private final @NotNull Terminal myTerminal;
   private final @NotNull TerminalTextBuffer myTerminalTextBuffer;
   private final @NotNull SettingsProvider mySettingsProvider;
+  private @NotNull TypeAheadTerminalModel.ShellType myShellType = ShellType.Unknown;
 
   private boolean isPredictionsApplied = false;
 
@@ -80,6 +81,15 @@ public class JediTermTypeAheadModel implements TypeAheadTerminalModel {
   @Override
   public long getLatencyThreshold() {
     return mySettingsProvider.getTypeAheadSettings().getLatencyThreshold();
+  }
+
+  @Override
+  public @NotNull ShellType getShellType() {
+    return myShellType;
+  }
+
+  public void setShellType(ShellType shellType) {
+    myShellType = shellType;
   }
 
   @Override

--- a/typeahead/src/com/jediterm/typeahead/TerminalTypeAheadManager.java
+++ b/typeahead/src/com/jediterm/typeahead/TerminalTypeAheadManager.java
@@ -10,7 +10,6 @@ import java.util.*;
 import java.util.concurrent.*;
 
 import com.jediterm.typeahead.TypeAheadTerminalModel.LineWithCursorX;
-import static com.jediterm.typeahead.TypeAheadTerminalModel.LineWithCursorX.moveToWordBoundary;
 
 public class TerminalTypeAheadManager {
   public static final long MAX_TERMINAL_DELAY = TimeUnit.MILLISECONDS.toNanos(1500);
@@ -485,8 +484,7 @@ public class TerminalTypeAheadManager {
             && myIsShowingPredictions);
       case AltBackspace:
         int oldCursorX = newLineWCursorX.myCursorX;
-        newLineWCursorX.myCursorX =
-          moveToWordBoundary(newLineWCursorX.myLineText.toString(), newLineWCursorX.myCursorX, false);
+        newLineWCursorX.moveToWordBoundary(false, myTerminalModel.getShellType());
 
         if (newLineWCursorX.myCursorX < 0) {
           return new HardBoundary();
@@ -515,8 +513,10 @@ public class TerminalTypeAheadManager {
       case AltLeftArrow:
       case AltRightArrow:
         oldCursorX = newLineWCursorX.myCursorX;
-        newLineWCursorX.myCursorX = moveToWordBoundary(newLineWCursorX.myLineText.toString(), newLineWCursorX.myCursorX,
-          keyEvent.myEventType == TypeAheadEvent.EventType.AltRightArrow);
+        newLineWCursorX.moveToWordBoundary(
+          keyEvent.myEventType == TypeAheadEvent.EventType.AltRightArrow,
+          myTerminalModel.getShellType()
+        );
 
         if (newLineWCursorX.myCursorX < 0 || newLineWCursorX.myCursorX
           >= Math.max(newLineWCursorX.myLineText.length() + 1, myTerminalModel.getTerminalWidth())) {

--- a/typeahead/tests/src/com/jediterm/typeahead/TerminalTypeAheadManagerTest.java
+++ b/typeahead/tests/src/com/jediterm/typeahead/TerminalTypeAheadManagerTest.java
@@ -327,6 +327,7 @@ public class TerminalTypeAheadManagerTest extends TestCase {
     long latencyThreshold = 0;
     boolean typeAheadEnabled = true;
     boolean isUsingAlternateBuffer = false;
+    ShellType shellType = ShellType.Bash;
 
     private final List<Action> actions;
 
@@ -390,6 +391,11 @@ public class TerminalTypeAheadManagerTest extends TestCase {
     @Override
     public long getLatencyThreshold() {
       return latencyThreshold;
+    }
+
+    @Override
+    public ShellType getShellType() {
+      return shellType;
     }
 
     void insertString(String text) {


### PR DESCRIPTION
In zsh alt+arrows works differently from bash. To fix this typeahead needs information about the shell it is communicating with. I changed TtyConnector interface so we can store this information with the process.