### PR TITLE
Updated gradle dependencies to be compatible with gradle 7

### DIFF
--- a/JediTerm/build.gradle
+++ b/JediTerm/build.gradle
@@ -32,17 +32,17 @@ sourceSets {
 }
 
 dependencies {
-    compile project(':pty')
+    implementation project(':pty')
 
-    compile ":eawtstub:"
+    implementation ":eawtstub:"
 
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile "org.jetbrains:annotations:13.0"
-    compile 'net.java.dev.jna:jna:4.5.0'
-    compile 'net.java.dev.jna:jna-platform:4.5.0'
-    compile ":trove4j:"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains:annotations:13.0"
+    implementation 'net.java.dev.jna:jna:4.5.0'
+    implementation 'net.java.dev.jna:jna-platform:4.5.0'
+    implementation ":trove4j:"
 }
 
 mainClassName = "com.jediterm.app.JediTermMain"

--- a/pty/build.gradle
+++ b/pty/build.gradle
@@ -15,13 +15,13 @@ repositories {
 dependencies {
     compile project(':terminal')
 
-    compile 'log4j:log4j:1.2.17'
-    compile 'org.jetbrains:annotations:20.1.0'
-    compile 'com.google.guava:guava:30.1.1-jre'
+    implementation 'log4j:log4j:1.2.17'
+    implementation 'org.jetbrains:annotations:20.1.0'
+    implementation 'com.google.guava:guava:30.1.1-jre'
 
-    compile 'org.jetbrains.pty4j:pty4j:0.12.0'
+    implementation 'org.jetbrains.pty4j:pty4j:0.12.0'
 
-    testCompile 'junit:junit:4.13.2'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 archivesBaseName = "jediterm-pty"

--- a/ssh/build.gradle
+++ b/ssh/build.gradle
@@ -8,14 +8,14 @@ sourceSets {
 dependencies {
     compile project(':terminal')
 
-    compile 'log4j:log4j:1.2.14'
-    compile 'org.jetbrains:annotations:13.0'
-    compile 'com.google.guava:guava:25.1-jre'
+    implementation 'log4j:log4j:1.2.14'
+    implementation 'org.jetbrains:annotations:13.0'
+    implementation 'com.google.guava:guava:25.1-jre'
 
-    compile 'com.jcraft:jsch:0.1.54'
-    compile 'com.jcraft:jzlib:1.1.3'
+    implementation 'com.jcraft:jsch:0.1.54'
+    implementation 'com.jcraft:jzlib:1.1.3'
 
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }
 
 mainClassName = 'com.jediterm.ssh.SshMain'

--- a/terminal/build.gradle
+++ b/terminal/build.gradle
@@ -21,13 +21,13 @@ tasks.withType(JavaCompile) {
 }
 
 dependencies {
-    compile project(':typeahead')
+    implementation project(':typeahead')
 
-    compile 'log4j:log4j:1.2.17'
-    compile 'org.jetbrains:annotations:20.1.0'
-    compile 'com.google.guava:guava:30.1.1-jre'
+    implementation 'log4j:log4j:1.2.17'
+    implementation 'org.jetbrains:annotations:20.1.0'
+    implementation 'com.google.guava:guava:30.1.1-jre'
 
-    testCompile 'junit:junit:4.13.2'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 compileJava {

--- a/typeahead/build.gradle
+++ b/typeahead/build.gradle
@@ -26,11 +26,11 @@ repositories {
 }
 
 dependencies {
-    compile 'log4j:log4j:1.2.17'
-    compile 'org.jetbrains:annotations:20.1.0'
-    compile 'com.google.guava:guava:30.1.1-jre'
+    implementation 'log4j:log4j:1.2.17'
+    implementation 'org.jetbrains:annotations:20.1.0'
+    implementation 'com.google.guava:guava:30.1.1-jre'
 
-    testCompile 'junit:junit:4.13.2'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 compileJava {


### PR DESCRIPTION
Gradle has deprecated `compile` and `testCompile` for some time and has replaced them with `implementation` and `testImplementation` respectively. From version 7 onwards the old dependency types are no longer supported, this commit migrates the dependencies to the new types.