### PR TITLE
Correct handling of function/cursor key modifiers

### DIFF
--- a/terminal/src/com/jediterm/terminal/TerminalKeyEncoder.java
+++ b/terminal/src/com/jediterm/terminal/TerminalKeyEncoder.java
@@ -39,8 +39,8 @@ public class TerminalKeyEncoder {
     putCode(VK_F8, ESC, '[', '1', '9', '~');
     putCode(VK_F9, ESC, '[', '2', '0', '~');
     putCode(VK_F10, ESC, '[', '2', '1', '~');
-    putCode(VK_F11, ESC, '[', '2', '3', '~', ESC);
-    putCode(VK_F12, ESC, '[', '2', '4', '~', Ascii.BS);
+    putCode(VK_F11, ESC, '[', '2', '3', '~');
+    putCode(VK_F12, ESC, '[', '2', '4', '~');
 
     putCode(VK_INSERT, ESC, '[', '2', '~');
     putCode(VK_DELETE, ESC, '[', '3', '~');

--- a/terminal/src/com/jediterm/terminal/TerminalKeyEncoder.java
+++ b/terminal/src/com/jediterm/terminal/TerminalKeyEncoder.java
@@ -50,6 +50,8 @@ public class TerminalKeyEncoder {
 
     putCode(VK_HOME, ESC, '[', 'H');
     putCode(VK_END, ESC, '[', 'F');
+
+    putCode(new KeyCodeAndModifier(VK_TAB, InputEvent.SHIFT_MASK), ESC, '[', 'Z');
   }
 
   public void arrowKeysApplicationSequences() {

--- a/terminal/tests/src/com/jediterm/TerminalKeyEncoderTest.java
+++ b/terminal/tests/src/com/jediterm/TerminalKeyEncoderTest.java
@@ -24,4 +24,29 @@ public class TerminalKeyEncoderTest extends TestCase {
     byte[] expected = UIUtil.isMac ? new byte[]{Ascii.ESC, 'b'} : new byte[]{Ascii.ESC, '[', '1', ';', '3', 'D'};
     Assert.assertArrayEquals(expected, terminalKeyEncoder.getCode(KeyEvent.VK_LEFT, InputEvent.ALT_MASK));
   }
+
+  public void testShiftLeft() {
+    TerminalKeyEncoder terminalKeyEncoder = new TerminalKeyEncoder();
+    byte[] expected = new byte[]{Ascii.ESC, '[', '1', ';', '2', 'D'};
+    Assert.assertArrayEquals(expected, terminalKeyEncoder.getCode(KeyEvent.VK_LEFT, InputEvent.SHIFT_MASK));
+  }
+
+  public void testShiftLeftApplication() {
+    TerminalKeyEncoder terminalKeyEncoder = new TerminalKeyEncoder();
+    terminalKeyEncoder.arrowKeysApplicationSequences();
+    byte[] expected = new byte[]{Ascii.ESC, '[', '1', ';', '2', 'D'};
+    Assert.assertArrayEquals(expected, terminalKeyEncoder.getCode(KeyEvent.VK_LEFT, InputEvent.SHIFT_MASK));
+  }
+
+  public void testControlF1() {
+    TerminalKeyEncoder terminalKeyEncoder = new TerminalKeyEncoder();
+    byte[] expected = new byte[]{Ascii.ESC, '[', '1', ';', '5', 'P'};
+    Assert.assertArrayEquals(expected, terminalKeyEncoder.getCode(KeyEvent.VK_F1, InputEvent.CTRL_MASK));
+  }
+
+  public void testControlF11() {
+    TerminalKeyEncoder terminalKeyEncoder = new TerminalKeyEncoder();
+    byte[] expected = new byte[]{Ascii.ESC, '[', '2', '3', ';', '5', '~'};
+    Assert.assertArrayEquals(expected, terminalKeyEncoder.getCode(KeyEvent.VK_F11, InputEvent.CTRL_MASK));
+  }
 }


### PR DESCRIPTION
tl;dr: Jediterm's handling of modifiers with function/cursor keys appears to be incorrect, and this PR changes it to match the behavior of other xterm-compatible terminal emulators.

Some examples of how jediterm 2.69 differs from xterm when modifier keys are used:

| input         | in xterm | +shift   | in jediterm | +shift    |
|---------------|----------|----------|-------------|-----------|
| left          | ^[[D     | ^[[1;2D  | ^[[D        | ^[[2D[^1] |
| left (DECCKM) | ^[OD     | ^[[1;2D  | ^[OD        | ^[O2D     |
| f1            | ^[OP     | ^[[1;2P  | ^[OP        | ^[OP      |
| f5            | ^[[15~   | ^[[15;2~ | ^[[15~      | ^[[15~    |
| f12           | ^[[24~   | ^[[24;2~ | ^[[24~^H    | ^[[24~^H  |
| del           | ^[[3~    | ^[[3;2~  | ^[[3~       | ^[[3~     |
| tab           | ^I       | ^[[Z     | ^I          | ^I        |

[^1]: [The patch for IDEA-283023](https://github.com/JetBrains/jediterm/commit/f0edb54dcc7c7519c6c224186a5e35ae1ef7e488) fixed some specific examples of this case by hardcoding a few special cases, but did not address the root cause.  This PR leaves the special cases in place, as they aren't causing any problems.

The cause (for everything other than tab) is found in TerminalKeyEncoder's `getCodeWithModifiers` method. This has a comment "Refer to section [PC-Style Function Keys](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-PC-Style-Function-Keys) in [http://invisible-island.net/xterm/ctlseqs/ctlseqs.html]()", which is indeed the documentation of how this should all work.  Comparing it to the jediterm code, there are several problems:

1. The method is only called at all for cursor keys, home, and end -- it should also be called for function keys etc.
2. The method should be replacing `SS3` with `CSI` when inserting modifiers.
   `SS3` only modifies a single character, so `SS3 2D` means `SS3 2` (which is not defined) followed by a literal `D`.
3. Since the modifier is encoded as an extra parameter to the control sequence, it is necessary to provide explicit values for any previous parameters.
   e.g. `CSI D` needs to become `CSI 1;<x>D`, because `CSI <x>D` means "move left \<x> characters".
4. jediterm adds an ESC to F11 and a BS to F12 that I believe should not be there.

This PR fixes those four issues, so that jediterm emits the same code sequences as xterm for these keypresses.
