### PR TITLE
send cursor keys on mouse wheel on alternative screen

### DIFF
--- a/terminal/src/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/terminal/src/com/jediterm/terminal/ui/TerminalPanel.java
@@ -985,6 +985,19 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Termin
         Point p = panelToCharCoords(e.getPoint());
         listener.mouseWheelMoved(p.x, p.y, e);
       }
+      if (myTerminalTextBuffer.isUsingAlternateBuffer() && mySettingsProvider.sendArrowKeysInAlternativeMode()){
+        //Send Arrow keys instead
+        final byte[] arrowKeys;
+        if (e.getWheelRotation() < 0) {
+          arrowKeys = myTerminalStarter.getCode(KeyEvent.VK_UP,0);
+        }else{
+          arrowKeys = myTerminalStarter.getCode(KeyEvent.VK_DOWN,0);
+        }
+        for(int i = 0; i < Math.abs(e.getUnitsToScroll()); i++){
+          myTerminalStarter.sendBytes(arrowKeys);
+        }
+        e.consume();
+      }
     });
 
     addMouseMotionListener(new MouseMotionAdapter() {

--- a/terminal/src/com/jediterm/terminal/ui/settings/DefaultSettingsProvider.java
+++ b/terminal/src/com/jediterm/terminal/ui/settings/DefaultSettingsProvider.java
@@ -228,4 +228,9 @@ public class DefaultSettingsProvider implements SettingsProvider {
   public @NotNull TerminalTypeAheadSettings getTypeAheadSettings() {
     return TerminalTypeAheadSettings.DEFAULT;
   }
+
+  @Override
+  public boolean sendArrowKeysInAlternativeMode() {
+    return true;
+  }
 }

--- a/terminal/src/com/jediterm/terminal/ui/settings/UserSettingsProvider.java
+++ b/terminal/src/com/jediterm/terminal/ui/settings/UserSettingsProvider.java
@@ -63,4 +63,6 @@ public interface UserSettingsProvider {
   boolean ambiguousCharsAreDoubleWidth();
 
   @NotNull TerminalTypeAheadSettings getTypeAheadSettings();
+
+  boolean sendArrowKeysInAlternativeMode();
 }


### PR DESCRIPTION
When using an application which enables an alternative screen, such as "nano" or "vi",  it would be great to "simulate" scrolling with mouse wheel by sending cursor keys. This practice is also implemented by some other terminals like vte and konsole according to https://terminalguide.namepad.de/mode/p1007/

I am  new to this project so feel free for adding any comments/changes.