### PR TITLE
Implemented text blinking

### DIFF
--- a/core/src/com/jediterm/terminal/TextStyle.java
+++ b/core/src/com/jediterm/terminal/TextStyle.java
@@ -102,7 +102,8 @@ public class TextStyle {
   public enum Option {
     BOLD,
     ITALIC,
-    BLINK,
+    SLOW_BLINK,
+    RAPID_BLINK,
     DIM,
     INVERSE,
     UNDERLINED,

--- a/core/src/com/jediterm/terminal/emulator/JediEmulator.java
+++ b/core/src/com/jediterm/terminal/emulator/JediEmulator.java
@@ -929,8 +929,13 @@ public class JediEmulator extends DataStreamIteratingEmulator {
         case 4:// Underlined
           builder.setOption(TextStyle.Option.UNDERLINED, true);
           break;
-        case 5:// Blink (appears as Bold)
-          builder.setOption(TextStyle.Option.BLINK, true);
+        case 5:// Slow Blink
+          builder.setOption(TextStyle.Option.SLOW_BLINK, true);
+          builder.setOption(TextStyle.Option.RAPID_BLINK, false);
+          break;
+        case 6:// Rapid Blink
+          builder.setOption(TextStyle.Option.SLOW_BLINK, false);
+          builder.setOption(TextStyle.Option.RAPID_BLINK, true);
           break;
         case 7:// Inverse
           builder.setOption(TextStyle.Option.INVERSE, true);
@@ -949,7 +954,8 @@ public class JediEmulator extends DataStreamIteratingEmulator {
           builder.setOption(TextStyle.Option.UNDERLINED, false);
           break;
         case 25: //Steady (not blinking)
-          builder.setOption(TextStyle.Option.BLINK, false);
+          builder.setOption(TextStyle.Option.SLOW_BLINK, false);
+          builder.setOption(TextStyle.Option.RAPID_BLINK, false);
           break;
         case 27: //Positive (not inverse)
           builder.setOption(TextStyle.Option.INVERSE, false);

--- a/ui/src/com/jediterm/terminal/ui/settings/UserSettingsProvider.java
+++ b/ui/src/com/jediterm/terminal/ui/settings/UserSettingsProvider.java
@@ -40,6 +40,12 @@ public interface UserSettingsProvider {
 
   HyperlinkStyle.HighlightMode getHyperlinkHighlightingMode();
 
+  default boolean enableTextBlink() { return false; }
+
+  default int slowTextBlinkMs() { return 1000; }
+
+  default int rapidTextBlinkMs() { return 500; }
+
   boolean useInverseSelectionColor();
 
   boolean copyOnSelect();


### PR DESCRIPTION
Implemented blinking when using ANSI escape characters for both slow and rapid blinking.

Disabled by default, with preset values of 1000ms for slow and 500ms for rapid.

Blinking is done by inverting the text style and triggering a repaint.