### PR TITLE
Avoid myCursorX dropping below 0

### DIFF
--- a/core/src/com/jediterm/terminal/model/JediTerminal.java
+++ b/core/src/com/jediterm/terminal/model/JediTerminal.java
@@ -1090,7 +1090,7 @@ public class JediTerminal implements Terminal, TerminalMouseListener, TerminalCo
           myCursorX += 1;
         }
       } else {
-        myCursorX -= 1; //low surrogate character can't be the first character in the line
+        if (myCursorX > 0) myCursorX -= 1; //low surrogate character can't be the first character in the line
       }
     }
   }


### PR DESCRIPTION
This probably fixes #198

The `JediTerminal`'s method `adjustXY()` decrements `myCursorX` without checking its value in some cases, so it might drop below 0 causing a crash.