### PR TITLE
Fix ED erasing not erasing the last line

### DIFF
--- a/core/src/com/jediterm/terminal/model/JediTerminal.java
+++ b/core/src/com/jediterm/terminal/model/JediTerminal.java
@@ -414,9 +414,7 @@ public class JediTerminal implements Terminal, TerminalMouseListener, TerminalCo
           break;
       }
       // Rest of lines
-      if (beginY != endY) {
-        clearLines(beginY, endY);
-      }
+      clearLines(beginY, endY);
     } finally {
       myTerminalTextBuffer.unlock();
     }


### PR DESCRIPTION
The ED erase command skips the last line when the cursor is at the before-last line. This simply leaves the bound check in the clearLines method to handle this case.

PoC that goes to the last line, fills the line with `X`, goes up one line, and erase everything from cursor to end and below:
```
# Assuming we have 80 columns
printf "\x1b[$(tput lines);1H%s\x1b[A\x1b[J" "$(printf 'X%.0s' {1..80})"
```

Before:
<img width="772" height="570" alt="image" src="https://github.com/user-attachments/assets/8ea889d5-f971-4d79-a182-63d25ef886e5" />

After:
<img width="772" height="570" alt="image" src="https://github.com/user-attachments/assets/de7b4f94-e4d9-4383-988b-c04098d0aaa5" />
