### PR TITLE
emulator: fix control sequence parsing of intermediates

### DIFF
--- a/core/src/com/jediterm/terminal/emulator/ControlSequence.java
+++ b/core/src/com/jediterm/terminal/emulator/ControlSequence.java
@@ -17,6 +17,8 @@ public class ControlSequence {
 
   private ArrayList<Character> myUnhandledChars;
 
+  private ArrayList<Character> myIntermediateChars;
+
   private boolean myStartsWithExclamationMark = false; // true when CSI !
   private boolean myStartsWithQuestionMark = false; // true when CSI ?
   private boolean myStartsWithMoreMark = false; // true when CSI >
@@ -68,6 +70,10 @@ public class ControlSequence {
         digit++;
         seenDigit = 1;
       }
+      else if (0x20 <= b && b <= 0x2F) {
+        // Intermediate bytes - valid inside CSI but not parameters.
+        addIntermediate(b);
+      }
       else if (':' <= b && b <= '?') {
         addUnhandled(b);
       }
@@ -87,6 +93,13 @@ public class ControlSequence {
       myUnhandledChars = new ArrayList<>();
     }
     myUnhandledChars.add(b);
+  }
+
+  private void addIntermediate(final char b) {
+    if (myIntermediateChars == null) {
+      myIntermediateChars = new ArrayList<>();
+    }
+    myIntermediateChars.add(b);
   }
 
   public boolean pushBackReordered(final TerminalDataStream channel) throws IOException {
@@ -184,6 +197,10 @@ public class ControlSequence {
 
   public boolean startsWithMoreMark() {
     return myStartsWithMoreMark;
+  }
+
+  public ArrayList<Character> getIntermediateChars() {
+    return myIntermediateChars;
   }
 
   public @NotNull String getDebugInfo() {

--- a/core/src/com/jediterm/terminal/emulator/JediEmulator.java
+++ b/core/src/com/jediterm/terminal/emulator/JediEmulator.java
@@ -777,7 +777,6 @@ public class JediEmulator extends DataStreamIteratingEmulator {
   }
 
   private boolean cursorShape(ControlSequence args) {
-    myTerminal.cursorBackward(1);
     switch (args.getArg(0, 0)) {
       case 0:
       case 1:


### PR DESCRIPTION
Bytes 0x20 to 0x2F are defined as "intermediate" characters. Store these in an new ArrayList instead of as unhandled. When parsing the
sequence used to change the cursor shape ("\x1b[<n> q"), the space between <n> and q is stored as an intermediate, and played back later.
This causes a disappearing character to happen anytime the cursor shape is changed.

Reference: https://vt100.net/emu/dec_ansi_parser
Fixes: #255
