### PR TITLE
input: improve touchpad scroll event handling

### DIFF
--- a/ui/src/com/jediterm/terminal/ui/input/AwtMouseEvent.java
+++ b/ui/src/com/jediterm/terminal/ui/input/AwtMouseEvent.java
@@ -29,10 +29,13 @@ public final class AwtMouseEvent extends MouseEvent {
     } else if (SwingUtilities.isRightMouseButton(awtMouseEvent)) {
       return MouseButtonCodes.NONE; //we don't handle right mouse button as it used for the context menu invocation
     } else if (awtMouseEvent instanceof java.awt.event.MouseWheelEvent) {
-      if (((java.awt.event.MouseWheelEvent) awtMouseEvent).getWheelRotation() > 0) {
+      int rotation = ((java.awt.event.MouseWheelEvent) awtMouseEvent).getWheelRotation();
+      if (rotation > 0) {
         return MouseButtonCodes.SCROLLUP;
-      } else {
+      } else if (rotation < 0) {
         return MouseButtonCodes.SCROLLDOWN;
+      } else {
+        return MouseButtonCodes.NONE; // Ignore rotation=0 events
       }
     }
     return MouseButtonCodes.NONE;

--- a/ui/src/com/jediterm/terminal/ui/input/AwtMouseWheelEvent.java
+++ b/ui/src/com/jediterm/terminal/ui/input/AwtMouseWheelEvent.java
@@ -7,7 +7,7 @@ public final class AwtMouseWheelEvent extends MouseWheelEvent {
   private final java.awt.event.MouseWheelEvent myAwtMouseWheelEvent;
 
   public AwtMouseWheelEvent(@NotNull java.awt.event.MouseWheelEvent awtMouseWheelEvent) {
-    super(AwtMouseEvent.createButtonCode(awtMouseWheelEvent), AwtMouseEvent.createButtonCode(awtMouseWheelEvent));
+    super(AwtMouseEvent.createButtonCode(awtMouseWheelEvent), AwtMouseEvent.getModifierKeys(awtMouseWheelEvent));
     myAwtMouseWheelEvent = awtMouseWheelEvent;
   }
 


### PR DESCRIPTION
Touchpad scrolls generate more precise input events, and sometimes contain
rotation = 0 events. The previous implemention generated scroll down events from
these types of events, resulting in erratic scroll behavior when touchpads are
used. Only emit a MouseWheel event if the rotation is not 0.

Additionally, the button code was incorrectly being passed as the modifier keys.
