### PR TITLE
Fix incorrect scrolling behavior in tmux

### DIFF
--- a/core/src/com/jediterm/terminal/emulator/JediEmulator.java
+++ b/core/src/com/jediterm/terminal/emulator/JediEmulator.java
@@ -8,6 +8,8 @@ import com.jediterm.terminal.emulator.mouse.MouseFormat;
 import com.jediterm.terminal.emulator.mouse.MouseMode;
 import com.jediterm.terminal.util.CharUtils;
 import org.jetbrains.annotations.NotNull;
+import com.jediterm.terminal.model.CharBuffer;
+import com.jediterm.terminal.model.JediTerminal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -776,6 +778,11 @@ public class JediEmulator extends DataStreamIteratingEmulator {
     } else if (c == 6) {
       int row = myTerminal.getCursorY();
       int column = myTerminal.getCursorX();
+
+      if (myTerminal instanceof JediTerminal && ((JediTerminal) myTerminal).isOriginMode()) {
+        row -= (((JediTerminal) myTerminal).getScrollRegionTop() - 1);
+      }
+
       String str = "\033[" + row + ";" + column + "R";
 
       LOG.debug("Sending Device Report Status : " + str);

--- a/core/src/com/jediterm/terminal/model/JediTerminal.java
+++ b/core/src/com/jediterm/terminal/model/JediTerminal.java
@@ -122,7 +122,18 @@ public class JediTerminal implements Terminal, TerminalMouseListener, TerminalCo
       myTerminalTextBuffer.setLineWrapped(myCursorY - 1, false);
       if (isAutoWrap()) {
         myTerminalTextBuffer.setLineWrapped(myCursorY - 1, true);
-        myCursorY += 1;
+        moveCursorDownOrScroll();
+      }
+    }
+  }
+
+  private void moveCursorDownOrScroll() {
+    if (myCursorY == myScrollRegionBottom) {
+      scrollArea(myScrollRegionTop, scrollingRegionSize(), -1);
+    } else {
+      myCursorY += 1;
+      if (myCursorY > myTerminalHeight) {
+        myCursorY = myTerminalHeight;
       }
     }
   }
@@ -192,14 +203,9 @@ public class JediTerminal implements Terminal, TerminalMouseListener, TerminalCo
   public void scrollY() {
     myTerminalTextBuffer.lock();
     try {
-      if (myCursorY > myScrollRegionBottom) {
-        final int dy = myScrollRegionBottom - myCursorY;
-        myCursorY = myScrollRegionBottom;
-        scrollArea(myScrollRegionTop, scrollingRegionSize(), dy);
+      if (myCursorY > myTerminalHeight) {
+        myCursorY = myTerminalHeight;
         myDisplay.setCursor(myCursorX, myCursorY);
-      }
-      if (myCursorY < myScrollRegionTop) {
-        myCursorY = myScrollRegionTop;
       }
     } finally {
       myTerminalTextBuffer.unlock();
@@ -214,9 +220,8 @@ public class JediTerminal implements Terminal, TerminalMouseListener, TerminalCo
   @Override
   public void newLine() {
     myCursorYChanged = true;
-    myCursorY += 1;
-
-    scrollY();
+    
+    moveCursorDownOrScroll();
 
     if (isAutoNewLine()) {
       carriageReturn();
@@ -716,7 +721,7 @@ public class JediTerminal implements Terminal, TerminalMouseListener, TerminalCo
       myCursorX = Math.max(0, x - 1);
       myCursorX = Math.min(myCursorX, myTerminalWidth - 1);
 
-      myCursorY = Math.max(0, myCursorY);
+      myCursorY = Math.max(1, myCursorY);
 
       adjustXY(-1);
 
@@ -754,6 +759,10 @@ public class JediTerminal implements Terminal, TerminalMouseListener, TerminalCo
   @Override
   public void resetScrollRegions() {
     setScrollingRegion(1, myTerminalHeight);
+  }
+
+  public int getScrollRegionTop() {
+    return myScrollRegionTop;
   }
 
   @Override

--- a/core/tests/src/com/jediterm/EmulatorTest.java
+++ b/core/tests/src/com/jediterm/EmulatorTest.java
@@ -20,9 +20,9 @@ import java.util.List;
 public class EmulatorTest extends EmulatorTestAbstract {
   public void testSetCursorPosition() throws IOException {
     doTest(3, 4, "X00\n" +  //X wins
-            "0X \n" +
-            "X X\n" +
-            "   \n");
+          "0X \n" +
+          "X X\n" +
+          "   \n");
   }
 
   //public void testTooLargeScrollRegion() throws IOException { TODO: this test fails on Travis somehow
@@ -198,6 +198,42 @@ public class EmulatorTest extends EmulatorTestAbstract {
     )));
     assertScreenLines(session, List.of(
       "foo bar"
+    ));
+  }
+
+  public void testDeviceStatusReportWithOriginMode() throws IOException {
+    TestSession session = new TestSession(80, 24);
+    // Set scrolling region to lines 2-23 (leaving 1 line at top and bottom).
+    session.process("\u001B[2;23r");
+    // Set Origin Mode (DECOM).
+    session.process("\u001B[?6h");
+    // Move cursor to 1,1 (relative to scrolling region, so absolute 2,1).
+    session.process("\u001B[1;1H");
+    assertEquals(2,session.getTerminal().getCursorY());
+    // Request Cursor Position (DSR).
+    session.process("\u001B[6n");
+    String response = session.getTerminal().getOutputAndClear();
+    assertEquals("\u001B[1;1R", response);
+  }
+
+  public void testNoScrollWhenOutsideScrollRegion() throws IOException {
+    TestSession session = new TestSession(80, 5);
+    // Set scrolling region to lines 1-3.
+    session.process("\u001B[1;3r");
+    // Fill lines 1-3.
+    session.process("Line 1\r\nLine 2\r\nLine 3");
+    // Move to line 4 (outside region).
+    session.process("\u001B[4;1H");
+    session.process("Line 4");
+    // Newline at line 4 should move to line 5 and NOT scroll region 1-3.
+    session.process("\r\n");
+    session.process("Line 5");
+    assertScreenLines(session,List.of(
+      "Line 1",
+      "Line 2",
+      "Line 3",
+      "Line 4",
+      "Line 5"
     ));
   }
 


### PR DESCRIPTION
JediTerm was incorrectly handling cursor movement when the cursor was located outside the active scrolling region (e.g. updating a status bar). If the cursor was below the scroll region, operations like newlines would trigger a scroll of the main content area, causing visual corruption.

This change ensures scrolling only occurs when the cursor is strictly at the bottom edge of the defined scrolling region.

Also fixes DSR (Device Status Report) to respect Origin Mode by reporting coordinates relative to the scrolling region instead of absolute screen coordinates.

Fixes #148.
Related to https://youtrack.jetbrains.com/issue/IJPL-102697/JediTerm-mis-render-prompt-cursor-location-when-inside-tmux.

Before:
![jediterm_148_before](https://github.com/user-attachments/assets/27eed093-0c1b-4a5e-91c6-7191d1f941b6)

After:
![jediterm_148_after](https://github.com/user-attachments/assets/b5c62a06-72da-4694-8568-4897b4e4cdb0)
