### PR TITLE
Fix OSC color queries and add OSC 4 palette support

### DIFF
--- a/core/src/com/jediterm/terminal/Terminal.java
+++ b/core/src/com/jediterm/terminal/Terminal.java
@@ -172,6 +172,10 @@ public interface Terminal {
 
   @Nullable Color getWindowBackground();
 
+  default @Nullable Color getPaletteColor(int index) {
+    return null;
+  }
+
   default void addApplicationTitleListener(@NotNull TerminalApplicationTitleListener listener) {}
 
   default void removeApplicationTitleListener(@NotNull TerminalApplicationTitleListener listener) {}

--- a/core/src/com/jediterm/terminal/TerminalDisplay.java
+++ b/core/src/com/jediterm/terminal/TerminalDisplay.java
@@ -47,4 +47,8 @@ public interface TerminalDisplay {
   default @Nullable Color getWindowBackground() {
     return null;
   }
+
+  default @Nullable Color getPaletteColor(int index) {
+    return null;
+  }
 }

--- a/core/src/com/jediterm/terminal/TerminalOutputStream.java
+++ b/core/src/com/jediterm/terminal/TerminalOutputStream.java
@@ -11,4 +11,28 @@ public interface TerminalOutputStream {
   void sendBytes(byte @NotNull [] response, boolean userInput);
 
   void sendString(@NotNull String string, boolean userInput);
+
+  /**
+   * Sends a response string synchronously. Used for device status reports
+   * where the response must be written before returning.
+   * <p>
+   * The default implementation delegates to {@link #sendString(String, boolean)},
+   * which may be asynchronous. Implementations that use async write queues
+   * should override this method to ensure synchronous completion.
+   */
+  default void sendStringImmediately(@NotNull String string) {
+    sendString(string, false);
+  }
+
+  /**
+   * Sends response bytes synchronously. Used for device attributes
+   * where the response must be written before returning.
+   * <p>
+   * The default implementation delegates to {@link #sendBytes(byte[], boolean)},
+   * which may be asynchronous. Implementations that use async write queues
+   * should override this method to ensure synchronous completion.
+   */
+  default void sendBytesImmediately(byte @NotNull [] response) {
+    sendBytes(response, false);
+  }
 }

--- a/core/src/com/jediterm/terminal/TerminalStarter.java
+++ b/core/src/com/jediterm/terminal/TerminalStarter.java
@@ -169,10 +169,10 @@ public class TerminalStarter implements TerminalOutputStream {
 
   @Override
   public void sendBytes(byte @NotNull [] bytes, boolean userInput) {
-    if (userInput) {
-      TerminalTypeAheadManager.TypeAheadEvent.fromByteArray(bytes).forEach(myTypeAheadManager::onKeyEvent);
-    }
     execute(() -> {
+      if (userInput) {
+        TerminalTypeAheadManager.TypeAheadEvent.fromByteArray(bytes).forEach(myTypeAheadManager::onKeyEvent);
+      }
       synchronized (myWriteLock) {
         int length = bytes.length;
         if (length > 0) {
@@ -206,10 +206,10 @@ public class TerminalStarter implements TerminalOutputStream {
 
   @Override
   public void sendString(@NotNull String string, boolean userInput) {
-    if (userInput) {
-      TerminalTypeAheadManager.TypeAheadEvent.fromString(string).forEach(myTypeAheadManager::onKeyEvent);
-    }
     execute(() -> {
+      if (userInput) {
+        TerminalTypeAheadManager.TypeAheadEvent.fromString(string).forEach(myTypeAheadManager::onKeyEvent);
+      }
       synchronized (myWriteLock) {
         int length = string.length();
         if (length > 0) {

--- a/core/src/com/jediterm/terminal/TerminalStarter.java
+++ b/core/src/com/jediterm/terminal/TerminalStarter.java
@@ -34,6 +34,7 @@ public class TerminalStarter implements TerminalOutputStream {
 
   private final TerminalTypeAheadManager myTypeAheadManager;
   private final ScheduledExecutorService mySingleThreadScheduledExecutor;
+  private final Object myWriteLock = new Object();
   private volatile boolean myStopped = false;
   private volatile ScheduledFuture<?> myScheduledTtyConnectorResizeFuture;
   private volatile boolean myIsLastSentByteEscape = false;
@@ -173,16 +174,34 @@ public class TerminalStarter implements TerminalOutputStream {
       myIsLastSentByteEscape = bytes[length - 1] == KeyEvent.VK_ESCAPE;
     }
     execute(() -> {
-      try {
-        if (userInput) {
-          TerminalTypeAheadManager.TypeAheadEvent.fromByteArray(bytes).forEach(myTypeAheadManager::onKeyEvent);
+      synchronized (myWriteLock) {
+        try {
+          if (userInput) {
+            TerminalTypeAheadManager.TypeAheadEvent.fromByteArray(bytes).forEach(myTypeAheadManager::onKeyEvent);
+          }
+          myTtyConnector.write(bytes);
         }
+        catch (IOException e) {
+          logWriteError(e);
+        }
+      }
+    });
+  }
+
+  @Override
+  public void sendBytesImmediately(byte @NotNull [] bytes) {
+    int length = bytes.length;
+    if (length > 0) {
+      myIsLastSentByteEscape = bytes[length - 1] == KeyEvent.VK_ESCAPE;
+    }
+    synchronized (myWriteLock) {
+      try {
         myTtyConnector.write(bytes);
       }
       catch (IOException e) {
         logWriteError(e);
       }
-    });
+    }
   }
 
   @Override
@@ -192,17 +211,34 @@ public class TerminalStarter implements TerminalOutputStream {
       myIsLastSentByteEscape = string.charAt(length - 1) == KeyEvent.VK_ESCAPE;
     }
     execute(() -> {
-      try {
-        if (userInput) {
-          TerminalTypeAheadManager.TypeAheadEvent.fromString(string).forEach(myTypeAheadManager::onKeyEvent);
+      synchronized (myWriteLock) {
+        try {
+          if (userInput) {
+            TerminalTypeAheadManager.TypeAheadEvent.fromString(string).forEach(myTypeAheadManager::onKeyEvent);
+          }
+          myTtyConnector.write(string);
         }
+        catch (IOException e) {
+          logWriteError(e);
+        }
+      }
+    });
+  }
 
+  @Override
+  public void sendStringImmediately(@NotNull String string) {
+    int length = string.length();
+    if (length > 0) {
+      myIsLastSentByteEscape = string.charAt(length - 1) == KeyEvent.VK_ESCAPE;
+    }
+    synchronized (myWriteLock) {
+      try {
         myTtyConnector.write(string);
       }
       catch (IOException e) {
         logWriteError(e);
       }
-    });
+    }
   }
 
   private void logWriteError(@NotNull IOException e) {

--- a/core/src/com/jediterm/terminal/TerminalStarter.java
+++ b/core/src/com/jediterm/terminal/TerminalStarter.java
@@ -169,16 +169,16 @@ public class TerminalStarter implements TerminalOutputStream {
 
   @Override
   public void sendBytes(byte @NotNull [] bytes, boolean userInput) {
-    int length = bytes.length;
-    if (length > 0) {
-      myIsLastSentByteEscape = bytes[length - 1] == KeyEvent.VK_ESCAPE;
+    if (userInput) {
+      TerminalTypeAheadManager.TypeAheadEvent.fromByteArray(bytes).forEach(myTypeAheadManager::onKeyEvent);
     }
     execute(() -> {
       synchronized (myWriteLock) {
+        int length = bytes.length;
+        if (length > 0) {
+          myIsLastSentByteEscape = bytes[length - 1] == KeyEvent.VK_ESCAPE;
+        }
         try {
-          if (userInput) {
-            TerminalTypeAheadManager.TypeAheadEvent.fromByteArray(bytes).forEach(myTypeAheadManager::onKeyEvent);
-          }
           myTtyConnector.write(bytes);
         }
         catch (IOException e) {
@@ -190,11 +190,11 @@ public class TerminalStarter implements TerminalOutputStream {
 
   @Override
   public void sendBytesImmediately(byte @NotNull [] bytes) {
-    int length = bytes.length;
-    if (length > 0) {
-      myIsLastSentByteEscape = bytes[length - 1] == KeyEvent.VK_ESCAPE;
-    }
     synchronized (myWriteLock) {
+      int length = bytes.length;
+      if (length > 0) {
+        myIsLastSentByteEscape = bytes[length - 1] == KeyEvent.VK_ESCAPE;
+      }
       try {
         myTtyConnector.write(bytes);
       }
@@ -206,16 +206,16 @@ public class TerminalStarter implements TerminalOutputStream {
 
   @Override
   public void sendString(@NotNull String string, boolean userInput) {
-    int length = string.length();
-    if (length > 0) {
-      myIsLastSentByteEscape = string.charAt(length - 1) == KeyEvent.VK_ESCAPE;
+    if (userInput) {
+      TerminalTypeAheadManager.TypeAheadEvent.fromString(string).forEach(myTypeAheadManager::onKeyEvent);
     }
     execute(() -> {
       synchronized (myWriteLock) {
+        int length = string.length();
+        if (length > 0) {
+          myIsLastSentByteEscape = string.charAt(length - 1) == KeyEvent.VK_ESCAPE;
+        }
         try {
-          if (userInput) {
-            TerminalTypeAheadManager.TypeAheadEvent.fromString(string).forEach(myTypeAheadManager::onKeyEvent);
-          }
           myTtyConnector.write(string);
         }
         catch (IOException e) {
@@ -227,11 +227,11 @@ public class TerminalStarter implements TerminalOutputStream {
 
   @Override
   public void sendStringImmediately(@NotNull String string) {
-    int length = string.length();
-    if (length > 0) {
-      myIsLastSentByteEscape = string.charAt(length - 1) == KeyEvent.VK_ESCAPE;
-    }
     synchronized (myWriteLock) {
+      int length = string.length();
+      if (length > 0) {
+        myIsLastSentByteEscape = string.charAt(length - 1) == KeyEvent.VK_ESCAPE;
+      }
       try {
         myTtyConnector.write(string);
       }

--- a/core/src/com/jediterm/terminal/emulator/JediEmulator.java
+++ b/core/src/com/jediterm/terminal/emulator/JediEmulator.java
@@ -280,6 +280,8 @@ public class JediEmulator extends DataStreamIteratingEmulator {
           return true;
         }
         break;
+      case 4:
+        return processPaletteColorQuery(args);
       case 10:
       case 11:
         return processColorQuery(args);
@@ -324,6 +326,37 @@ public class JediEmulator extends DataStreamIteratingEmulator {
         LOG.debug("Responding to OSC " + ps + " query: " + str);
       }
       myTerminal.deviceStatusReport(str);
+    }
+    return true;
+  }
+
+  private boolean processPaletteColorQuery(@NotNull SystemCommandSequence args) {
+    List<String> argList = args.getArgs();
+    int argCount = argList.size();
+    if (argCount < 3) {
+      return false;
+    }
+    // Expect pairs of (index;?) after the first argument.
+    // If (argCount - 1) is odd, there is a trailing unpaired argument and the sequence is malformed.
+    if (((argCount - 1) & 1) != 0) {
+      return false;
+    }
+    for (int i = 1; i < argCount - 1; i += 2) {
+      int index = args.getIntAt(i, -1);
+      if (index < 0 || index >= 256) {
+        return false;
+      }
+      if (!"?".equals(args.getStringAt(i + 1))) {
+        return false;
+      }
+      Color color = myTerminal.getPaletteColor(index);
+      if (color != null) {
+        String str = args.format(List.of("4", String.valueOf(index), color.toXParseColor()));
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Responding to OSC 4 query for index " + index + ": " + str);
+        }
+        myTerminal.deviceStatusReport(str);
+      }
     }
     return true;
   }

--- a/core/src/com/jediterm/terminal/model/JediTerminal.java
+++ b/core/src/com/jediterm/terminal/model/JediTerminal.java
@@ -320,6 +320,11 @@ public class JediTerminal implements Terminal, TerminalMouseListener, TerminalCo
     return myDisplay.getWindowBackground();
   }
 
+  @Override
+  public @Nullable Color getPaletteColor(int index) {
+    return myDisplay.getPaletteColor(index);
+  }
+
   private final List<TerminalCustomCommandListener> myCustomCommandListeners = new CopyOnWriteArrayList<>();
 
   @Override
@@ -1045,14 +1050,14 @@ public class JediTerminal implements Terminal, TerminalMouseListener, TerminalCo
   @Override
   public void deviceStatusReport(String str) {
     if (myTerminalOutput != null) {
-      myTerminalOutput.sendString(str, false);
+      myTerminalOutput.sendStringImmediately(str);
     }
   }
 
   @Override
   public void deviceAttributes(byte[] response) {
     if (myTerminalOutput != null) {
-      myTerminalOutput.sendBytes(response, false);
+      myTerminalOutput.sendBytesImmediately(response);
     }
   }
 

--- a/core/tests/src/com/jediterm/EmulatorTest.java
+++ b/core/tests/src/com/jediterm/EmulatorTest.java
@@ -80,6 +80,32 @@ public class EmulatorTest extends EmulatorTestAbstract {
     Assert.assertEquals("\033]11;rgb:1010/0f0f/0e0e\u001B\\", session.getTerminal().getOutputAndClear());
   }
 
+  public void testOsc4Query() throws IOException {
+    TestSession session = new TestSession(10, 10);
+    session.process("\u001B]4;0;?\7");
+    Assert.assertEquals("\033]4;0;rgb:0000/0000/0000\7", session.getTerminal().getOutputAndClear());
+
+    session.process("\u001B]4;1;?\7");
+    Assert.assertEquals("\033]4;1;rgb:cdcd/0000/0000\7", session.getTerminal().getOutputAndClear());
+
+    session.process("\u001B]4;16;?\7");
+    Assert.assertEquals("\033]4;16;rgb:0000/0000/0000\7", session.getTerminal().getOutputAndClear());
+
+    session.process("\u001B]4;232;?\7");
+    Assert.assertEquals("\033]4;232;rgb:0808/0808/0808\7", session.getTerminal().getOutputAndClear());
+
+    session.process("\u001B]4;0;?\u001B\\");
+    Assert.assertEquals("\033]4;0;rgb:0000/0000/0000\u001B\\", session.getTerminal().getOutputAndClear());
+  }
+
+  public void testOsc4MultipleQuery() throws IOException {
+    TestSession session = new TestSession(10, 10);
+    session.process("\u001B]4;0;?;1;?\7");
+    String output = session.getTerminal().getOutputAndClear();
+    Assert.assertTrue(output.contains("\033]4;0;rgb:0000/0000/0000\7"));
+    Assert.assertTrue(output.contains("\033]4;1;rgb:cdcd/0000/0000\7"));
+  }
+
   public void testResetToInitialState() throws IOException {
     TestSession session = new TestSession(20, 4);
     for (int i = 1; i <= 9; i++) {

--- a/core/tests/src/com/jediterm/util/BackBufferDisplay.java
+++ b/core/tests/src/com/jediterm/util/BackBufferDisplay.java
@@ -114,7 +114,6 @@ public class BackBufferDisplay implements TerminalDisplay {
     if (index < 16) {
       return ColorPaletteImpl.XTERM_PALETTE.getForeground(TerminalColor.index(index));
     }
-    TerminalColor color = ColorPalette.getIndexedTerminalColor(index);
-    return color != null ? color.toColor() : null;
+    return ColorPalette.getIndexedTerminalColor(index).toColor();
   }
 }

--- a/core/tests/src/com/jediterm/util/BackBufferDisplay.java
+++ b/core/tests/src/com/jediterm/util/BackBufferDisplay.java
@@ -2,7 +2,10 @@ package com.jediterm.util;
 
 import com.jediterm.core.Color;
 import com.jediterm.terminal.CursorShape;
+import com.jediterm.terminal.TerminalColor;
 import com.jediterm.terminal.TerminalDisplay;
+import com.jediterm.terminal.emulator.ColorPalette;
+import com.jediterm.terminal.emulator.ColorPaletteImpl;
 import com.jediterm.terminal.emulator.mouse.MouseFormat;
 import com.jediterm.terminal.emulator.mouse.MouseMode;
 import com.jediterm.terminal.model.TerminalSelection;
@@ -101,5 +104,17 @@ public class BackBufferDisplay implements TerminalDisplay {
 
   public void setWindowBackground(@Nullable Color backgroundColor) {
     myBackgroundColor = backgroundColor;
+  }
+
+  @Override
+  public @Nullable Color getPaletteColor(int index) {
+    if (index < 0 || index >= 256) {
+      return null;
+    }
+    if (index < 16) {
+      return ColorPaletteImpl.XTERM_PALETTE.getForeground(TerminalColor.index(index));
+    }
+    TerminalColor color = ColorPalette.getIndexedTerminalColor(index);
+    return color != null ? color.toColor() : null;
   }
 }

--- a/ui/src/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/ui/src/com/jediterm/terminal/ui/TerminalPanel.java
@@ -1020,8 +1020,7 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Termin
     if (index < 16) {
       return getPalette().getForeground(TerminalColor.index(index));
     }
-    TerminalColor color = ColorPalette.getIndexedTerminalColor(index);
-    return color != null ? color.toColor() : null;
+    return ColorPalette.getIndexedTerminalColor(index).toColor();
   }
 
   private @NotNull java.awt.Color getEffectiveForeground(@NotNull TextStyle style) {

--- a/ui/src/com/jediterm/terminal/ui/TerminalPanel.java
+++ b/ui/src/com/jediterm/terminal/ui/TerminalPanel.java
@@ -1012,6 +1012,18 @@ public class TerminalPanel extends JComponent implements TerminalDisplay, Termin
     return toBackground(mySettingsProvider.getDefaultBackground());
   }
 
+  @Override
+  public @Nullable Color getPaletteColor(int index) {
+    if (index < 0 || index >= 256) {
+      return null;
+    }
+    if (index < 16) {
+      return getPalette().getForeground(TerminalColor.index(index));
+    }
+    TerminalColor color = ColorPalette.getIndexedTerminalColor(index);
+    return color != null ? color.toColor() : null;
+  }
+
   private @NotNull java.awt.Color getEffectiveForeground(@NotNull TextStyle style) {
     Color color = style.hasOption(Option.INVERSE) ? getBackground(style) : getForeground(style);
     return AwtTransformers.toAwtColor(color);


### PR DESCRIPTION
I was trying to get the "system" theme detection working in Opencode, which uses OSC 11 to query the terminal's background color. But the query wasn't working. The terminal would receive it but never respond.

The problem was that responses were being sent asynchronously. By the time the response was sent, the application had already finished reading. This PR makes those responses synchronous, which fixes the issue. I also added support for querying palette colors since that was something else I found that the Opencode 'system' theme relied on.

**Disclaimer:** I did use AI to help write this code, but I'm certainly doing my best here not to spam. I did verify the tests pass and my manual testing seemed to confirm the fix. I am not an expert in Terminal stuff or event Java for that matter. I'm happy to take feedback and improve this, or hand it off to someone with more experience.


