### PR TITLE
Update mouse reporting to include motion flag in mouseMoved

### DIFF
--- a/core/src/com/jediterm/terminal/model/JediTerminal.java
+++ b/core/src/com/jediterm/terminal/model/JediTerminal.java
@@ -995,7 +995,9 @@ public class JediTerminal implements Terminal, TerminalMouseListener, TerminalCo
     }
     if (shouldSendMouseData(MouseMode.MOUSE_REPORTING_ALL_MOTION)) {
       if (myTerminalOutput != null) {
-        myTerminalOutput.sendBytes(mouseReport(MouseButtonCodes.RELEASE, x + 1, y + 1), true);
+        myTerminalOutput.sendBytes(
+          mouseReport(MouseButtonCodes.RELEASE | MouseButtonModifierFlags.MOUSE_BUTTON_MOTION_FLAG, x + 1, y + 1), true
+        );
       }
     }
     myLastMotionReport = new Point(x, y);
@@ -1089,7 +1091,7 @@ public class JediTerminal implements Terminal, TerminalMouseListener, TerminalCo
    * Sets the URL hyperlink filter for parsing URLs in OSC8 links.
    * Please note it can be called with acquired `com.jediterm.terminal.model.TerminalTextBuffer#lock()`.
    * Therefore, to avoid deadlocks, it shouldn't acquire any other locks, like IntelliJ global read/write lock.
-   * 
+   *
    * @param urlHyperlinkFilter The URL hyperlink filter to set.
    */
   public void setUrlHyperlinkFilter(@Nullable HyperlinkFilter urlHyperlinkFilter) {


### PR DESCRIPTION
Fix #329 

While `JediTerminal::mouseDragged` implements the "Button-event tracking" spec correctly, `JediTerminal::mouseMoved` does not add the motion flag to the report, which [it should](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Any-event-tracking):

> Any-event mode is the same as button-event mode, except that all motion events are reported, even if no mouse button is down.

And from Button-event tracking:

> ( @  = 32 + 0 (button 1) + 32 (motion indicator)).  

This can cause issues in modern TUIs such as https://github.com/anomalyco/opentui/issues/931