### PR TITLE
Support CBT and CHT control sequences in the emulator and terminal model

### DIFF
--- a/core/src/com/jediterm/terminal/Terminal.java
+++ b/core/src/com/jediterm/terminal/Terminal.java
@@ -148,6 +148,10 @@ public interface Terminal {
 
   void setTabStopAtCursor();
 
+  int previousTab(int position);
+
+  int nextTab(int position);
+
   void writeUnwrappedString(String string);
 
   void setTerminalOutput(@Nullable TerminalOutputStream terminalOutput);

--- a/core/src/com/jediterm/terminal/emulator/JediEmulator.java
+++ b/core/src/com/jediterm/terminal/emulator/JediEmulator.java
@@ -466,6 +466,8 @@ public class JediEmulator extends DataStreamIteratingEmulator {
       case 'f':
       case 'H': //CUP
         return cursorPosition(args);
+      case 'I': //CHT
+        return cursorForwardTab(args.getArg(0, 1));
       case 'J': //DECSED
         return eraseInDisplay(args);
       case 'K': //EL
@@ -482,6 +484,8 @@ public class JediEmulator extends DataStreamIteratingEmulator {
         return scrollUp(args);
       case 'T': //SD
         return scrollDown(args);
+      case 'Z': //CBT
+        return cursorBackwardTab(args.getArg(0, 1));
       case 'c': //Send Device Attributes (Primary DA)
         if (args.startsWithMoreMark()) { //Send Device Attributes (Secondary DA)
           return sendSecondaryDeviceAttributes(args);
@@ -1176,5 +1180,32 @@ public class JediEmulator extends DataStreamIteratingEmulator {
 
   public void setMouseMode(MouseMode mouseMode) {
     myTerminal.setMouseMode(mouseMode);
+  }
+
+  private boolean cursorBackwardTab(int count) {
+    if (count == 0) count = 1;
+    int curX = myTerminal.getCursorX() - 1;
+    for (int i = 0; i < count && curX > 0; i++) {
+      curX = myTerminal.previousTab(curX);
+      if (curX < 0) {
+        curX = 0;
+      }
+    }
+    myTerminal.cursorPosition(curX + 1, myTerminal.getCursorY());
+    return true;
+  }
+
+  private boolean cursorForwardTab(int count) {
+    if (count == 0) count = 1;
+    int curX = myTerminal.getCursorX() - 1;
+    int width = myTerminal.getTerminalWidth();
+    for (int i = 0; i < count && curX < width - 1; i++) {
+      curX = myTerminal.nextTab(curX);
+      if (curX >= width) {
+        curX = width - 1;
+      }
+    }
+    myTerminal.cursorPosition(curX + 1, myTerminal.getCursorY());
+    return true;
   }
 }

--- a/core/src/com/jediterm/terminal/model/JediTerminal.java
+++ b/core/src/com/jediterm/terminal/model/JediTerminal.java
@@ -365,6 +365,16 @@ public class JediTerminal implements Terminal, TerminalMouseListener, TerminalCo
   }
 
   @Override
+  public int previousTab(int position) {
+    return myTabulator.previousTab(position);
+  }
+
+  @Override
+  public int nextTab(int position) {
+    return myTabulator.nextTab(position);
+  }
+
+  @Override
   public void eraseInDisplay(final int arg) {
     // ED (Erase in Display) https://vt100.net/docs/vt510-rm/ED.html
     myTerminalTextBuffer.lock();

--- a/core/tests/src/com/jediterm/EmulatorTest.java
+++ b/core/tests/src/com/jediterm/EmulatorTest.java
@@ -249,6 +249,28 @@ public class EmulatorTest extends EmulatorTestAbstract {
     ));
   }
 
+  public void testCursorBackwardTab() throws IOException {
+    TestSession session = new TestSession(24, 3);
+    session.process("\u001b[1;1H"); // move cursor to column 1
+    session.process("\t"); // tab to column 9
+    session.process("\t"); // tab to column 17
+    session.assertCursorPosition(17, 1);
+    session.process("\u001b[Z"); // CBT: back one tab stop
+    session.assertCursorPosition(9, 1);
+    session.process("\u001b[2Z"); // CBT: back two tab stops
+    session.assertCursorPosition(1, 1);
+  }
+
+  public void testCursorForwardTab() throws IOException {
+    TestSession session = new TestSession(24, 3);
+    session.process("\u001b[1;1H"); // move cursor to column 1
+    session.assertCursorPosition(1, 1);
+    session.process("\u001b[I"); // CHT: forward one tab stop
+    session.assertCursorPosition(9, 1);
+    session.process("\u001b[2I"); // CHT: forward two tab stops
+    session.assertCursorPosition(24, 1); // clamped at terminal width (last column)
+  }
+
   private void assertScreenLines(@NotNull TestSession session, @NotNull List<String> expectedScreenLines) {
     Assert.assertEquals(expectedScreenLines, TerminalLinesUtilKt.getLineTexts(session.getTerminalTextBuffer().getScreenLinesStorage()));
   }


### PR DESCRIPTION
When a terminal advertises itself as `xterm`, it is expected to support the `CBT` (Cursor Backward Tab). However, JediTerm's emulator did not support this control sequence, which caused some applications to behave incorrectly when running in JediTerm.

This commit adds support for the `CBT` control sequence in the `JediEmulator` class, as well as the corresponding `CHT` (Cursor Forward Tab) control sequence. The `Terminal` interface is updated to include methods for finding the previous and next tab stops, and the `JediTerminal` class implements these methods using its existing tabulator functionality.

Fixes: https://github.com/JetBrains/jediterm/issues/328